### PR TITLE
Result/Error Handling Extended

### DIFF
--- a/src/codecarto/containers/processor/api/routers/palette_router.py
+++ b/src/codecarto/containers/processor/api/routers/palette_router.py
@@ -1,10 +1,11 @@
 import os
+import traceback
 from json import load
 from fastapi import APIRouter
 from fastapi.responses import JSONResponse
-import traceback
 
 from src.plotter.palette import Theme
+from api.util import generate_return, proc_exception
 
 PaletteRoute: APIRouter = APIRouter()
 default_palette_path: str = "src/plotter/default_palette.json"
@@ -16,30 +17,11 @@ temp_palette_path: str = "src/plotter/palette.json"
 debug: bool = True
 
 
-def get_user_from_database(user_id: int) -> dict:
-    pass
-
-
-def load_palette_from_database(user_id: int) -> dict:
-    pass
-
-
-def save_palette_to_database(user_id: int, new_pal_data: dict) -> dict:
-    pass
-
-
 @PaletteRoute.get(
     "/get_palette",
 )
 async def get_palette(user_id: int = -1) -> dict:
     try:
-        # IF USER, LOOK UP USER PALETTE ID
-        if user_id != -1:
-            # get_user_from_database(user_id)
-            pass
-
-        # load_palette_from_database(user_id)
-
         # TODO: DEBUG - temporary solution
         if debug == True:
             file_path = temp_palette_path
@@ -51,12 +33,9 @@ async def get_palette(user_id: int = -1) -> dict:
             with open(file_path, "r") as f:
                 pal_data = load(f)
 
-        return pal_data
+        return generate_return("success", "Proc - Success", pal_data)
     except Exception as e:
-        traceback.print_exc()
-        return JSONResponse(
-            status_code=500, content={"Processor Palette Error": str(e)}
-        )
+        return proc_exception("error", "Proc - Could not get palette data", e)
 
 
 @PaletteRoute.get("/set_palette")

--- a/src/codecarto/containers/processor/api/routers/polygraph_router.py
+++ b/src/codecarto/containers/processor/api/routers/polygraph_router.py
@@ -1,22 +1,25 @@
 from fastapi import APIRouter
 
+from api.util import generate_return, proc_exception
+
 PolyGraphRoute = APIRouter()
 
 
 @PolyGraphRoute.get("/get_graph_desc")
 async def get_graph_desc() -> dict:
-    """Returns a dict[str:str] of graph description"""
-    from src.models.graph_data import get_graph_description
-
     try:
+        from src.models.graph_data import get_graph_description
+
         graph_desc: dict = get_graph_description()
 
-        return {
-            "graph_desc": graph_desc,
-            "status": "completed",
-        }
+        return generate_return(
+            "success",
+            "Graph description successfully fetched from processor.",
+            graph_desc,
+        )
     except Exception as e:
-        return {
-            "error": str(e),
-            "status": "failed",
-        }
+        return proc_exception(
+            "error",
+            "An error occurred while fetching graph description from processor.",
+            e,
+        )

--- a/src/codecarto/containers/processor/api/util.py
+++ b/src/codecarto/containers/processor/api/util.py
@@ -1,0 +1,18 @@
+def generate_return(status: str, message: str, results) -> dict:
+    return {
+        "status": status,  # success or error
+        "message": message,  # friendly message
+        "results": results,  # the actual results or the error message
+    }
+
+
+def proc_exception(status: str, message: str, exc) -> dict:
+    import traceback
+
+    tb_str = traceback.format_exception(type(exc), exc, exc.__traceback__)
+    tb_str = "".join(tb_str)
+    return generate_return(
+        status,
+        message,
+        {"e": exc, "traceback": tb_str},
+    )

--- a/src/codecarto/containers/processor/requirements.txt
+++ b/src/codecarto/containers/processor/requirements.txt
@@ -9,3 +9,5 @@ matplotlib
 mpld3
 scipy
 pydantic
+requests
+httpx

--- a/src/codecarto/containers/web/api/routers/plotter_router.py
+++ b/src/codecarto/containers/web/api/routers/plotter_router.py
@@ -1,7 +1,8 @@
 import httpx
-
 from fastapi import APIRouter, Request
 from fastapi.templating import Jinja2Templates
+
+from api.util import generate_return, web_exception
 
 PlotterRoute: APIRouter = APIRouter()
 pages = Jinja2Templates(directory="src/pages")
@@ -60,33 +61,48 @@ async def plot(
     """
     # Call the processor container
     async with httpx.AsyncClient(timeout=60.0) as client:
-        # returns a string of HTML representing plot
-        response = await client.get(
-            PROC_API_URL,
-            params={
-                "graph_data": graph_data,
-                "file": file,
-                "layout": layout,
-                "grid": grid,
-                "labels": labels,
-                "ntx": ntx,
-                "custom": custom,
-                "palette": palette,
-                "debug": debug,
-            },
-        )
-        if not response.status_code == 200:
-            return {"error": "Could not fetch plot from processor."}
-
         try:
-            plot_html = response.json()["plotted"]
-        except KeyError:
-            print("Received JSON:", response.json())  # Debugging line
-            return {"error": "Key 'plotted' not found in response"}
+            response = await client.get(
+                PROC_API_URL,
+                params={
+                    "graph_data": graph_data,
+                    "file": file,
+                    "layout": layout,
+                    "grid": grid,
+                    "labels": labels,
+                    "ntx": ntx,
+                    "custom": custom,
+                    "palette": palette,
+                    "debug": debug,
+                },
+            )
+            response.raise_for_status()
+            if not response.status_code == 200:
+                return generate_return(
+                    "error",
+                    "Web - Could not fetch plot from processor.",
+                    response.content,
+                )
+            return response.json()
 
-    return {
-        "plot_html": plot_html,
-        "layout": layout,
-        "file": file,
-        "status": "completed",
-    }
+            # plot_html = response.json()["results"] # response.json()["plotted"]
+            # return {
+            #     "plot_html": plot_html,
+            #     "layout": layout,
+            #     "file": file,
+            #     "status": "completed",
+            # }
+        except httpx.RequestError as exc:
+            # Handle network errors
+            return web_exception(
+                "error", "Web - An error occurred while requesting", exc
+            )
+        except httpx.HTTPStatusError as exc:
+            # Handle non-2xx responses
+            return web_exception(
+                "error", "Web - Error response from processor", exc.response.content
+            )
+        except KeyError:
+            return web_exception(
+                "error", "Web - Key 'results' not found in response", response.json()
+            )

--- a/src/codecarto/containers/web/api/util.py
+++ b/src/codecarto/containers/web/api/util.py
@@ -1,0 +1,18 @@
+def generate_return(status: str, message: str, results: str):
+    return {
+        "status": status,  # success or error
+        "message": message,  # friendly message
+        "results": results,  # the actual results or the error message
+    }
+
+
+def web_exception(status: str, message: str, exc) -> dict:
+    import traceback
+
+    tb_str = traceback.format_exception(type(exc), exc, exc.__traceback__)
+    tb_str = "".join(tb_str)
+    return generate_return(
+        status,
+        message,
+        {"e": exc, "traceback": tb_str},
+    )

--- a/src/codecarto/containers/web/src/pages/palette/palette.html
+++ b/src/codecarto/containers/web/src/pages/palette/palette.html
@@ -13,13 +13,13 @@
 <!-- BODY -->
 <main>
   <!-- Palette Desc -->
-  <section id="palette-desc">
+  <section id="palette_desc">
     <h2 style="margin-top: -20px">Palette</h2>
     <button onclick="window.location.href = '/'">Return Home</button>
   </section>
   <br />
   <!-- Palette Display -->
-  <section id="palette-display">
+  <section id="palette_display">
     <h2>Default Palette Properties</h2>
     <div id="pal_data"></div>
   </section>

--- a/src/codecarto/containers/web/src/pages/palette/palette.js
+++ b/src/codecarto/containers/web/src/pages/palette/palette.js
@@ -1,3 +1,48 @@
+async function getPalette() {
+  var href_line = `/palette/get_palette`
+  try {
+    const response = await fetch(href_line)
+    const responseData = await response.json()
+
+    if (response.ok) {
+      if (responseData.status === 'error') {
+        console.error(`Error with response data: ${responseData.message}`)
+        document.getElementById('pal_data').innerHTML = responseData.message
+      } else {
+        console.log(`Received response: ${responseData.message}`)
+        const data = responseData.results
+
+        // Create a string variable with the content of the <div>
+        let content = ''
+        for (const [key, value] of Object.entries(data)) {
+          // check if value is a dictionary
+          if (typeof value === 'object') {
+            content += `<button class="collapsible">${key}</button>`
+            content += `<div class="content">`
+            // if so, iterate through the dictionary
+            for (const [k, v] of Object.entries(value)) {
+              // Concatenating key-value pairs
+              content += `${k}: ${v}<br>`
+            }
+            // remove last <br>
+            content = content.slice(0, -4)
+            content += `</div><br>`
+          }
+        }
+        // Update the content of the <div>
+        document.getElementById('pal_data').innerHTML = content
+        attachCollapsibleListeners()
+      }
+    } else {
+      document.getElementById('pal_data').innerHTML = 'Network error'
+      console.error(`Error with response status: ${response.status}`)
+    }
+  } catch (error) {
+    document.getElementById('pal_data').innerHTML = 'Network error'
+    console.error('Error - palette.js - getPalette():', error)
+  }
+}
+
 function attachCollapsibleListeners() {
   var coll = document.getElementsByClassName('collapsible')
   var i
@@ -12,36 +57,4 @@ function attachCollapsibleListeners() {
       }
     })
   }
-}
-
-function getPalette() {
-  fetch('/palette/get_palette')
-    .then(response => response.json())
-    .then(data => {
-      // Create a string variable with the content of the <div>
-      let content = ''
-      for (const [key, value] of Object.entries(data)) {
-        // check if value is a dictionary
-        if (typeof value === 'object') {
-          content += `<button class="collapsible">${key}</button>`
-          content += `<div class="content">`
-          // if so, iterate through the dictionary
-          for (const [k, v] of Object.entries(value)) {
-            // Concatenating key-value pairs
-            content += `${k}: ${v}<br>`
-          }
-          // remove last <br>
-          content = content.slice(0, -4)
-          content += `</div><br>`
-        }
-      }
-      // Update the content of the <div>
-      document.getElementById('pal_data').innerHTML = content
-      attachCollapsibleListeners()
-    })
-    .catch(error => {
-      document.getElementById('pal_data').innerHTML =
-        'Error getting palette data'
-      console.error('An error occurred in palette.html getPalette():', error)
-    })
 }

--- a/src/codecarto/containers/web/src/pages/plot/plot.html
+++ b/src/codecarto/containers/web/src/pages/plot/plot.html
@@ -13,7 +13,7 @@
   <br /><br />
 
   <!-- Plot Configuration -->
-  <section id="plot-config">
+  <section id="plot_config">
     <h2>Plot Demo Graph</h2>
     <select name="layouts" id="layouts">
       <option value="Circular">Circular</option>
@@ -35,11 +35,11 @@
     <br />
     <button id="single" onclick="plot()">Single Layout</button>
     <button id="grid" onclick="plot(true)">Grid of all layouts</button>
-    <div id="plot-loader" class="loader" style="display: none">Loading ...</div>
+    <div id="plot_loader" class="loader" style="display: none">Loading ...</div>
   </section>
 
   <!-- Plot Display -->
-  <section id="plot-display">
+  <section id="plot_display">
     <div id="plot"></div>
   </section>
 </main>

--- a/src/codecarto/containers/web/src/pages/plot/plot.js
+++ b/src/codecarto/containers/web/src/pages/plot/plot.js
@@ -2,7 +2,7 @@ async function plot(all = false) {
   // Clear plot
   document.getElementById('plot').innerHTML = ''
   // Show spinner
-  document.getElementById('plot-loader').style.display = 'inline'
+  document.getElementById('plot_loader').style.display = 'inline'
 
   // get the current layout and run
   const layoutElement = document.getElementById('layouts')
@@ -10,6 +10,7 @@ async function plot(all = false) {
   const selectedLayout = layoutElement.value
   const selectedRun = runElement.value
 
+  // get the variables for the request
   let debug = false
   let file = selectedRun
   let layout = selectedLayout
@@ -24,26 +25,32 @@ async function plot(all = false) {
   }
   var href_line = `/plotter/plot?grid=false&debug=${debug}&file=${file}&layout=${layout}`
 
+  // make the request
   try {
+    document.getElementById('plot_loader').style.display = 'none'
     const response = await fetch(href_line)
-    document.getElementById('plot-loader').style.display = 'none'
-    console.log(`Received response: ${response.status}`)
     const responseData = await response.json()
-    console.log(`Received response: ${responseData.plot_html}`)
 
     if (response.ok) {
-      const plotHTML = responseData.plot_html
-      let newPlotHTML = stylePlotHTML(plotHTML)
+      if (responseData.status === 'error') {
+        console.error(`Error with response data: ${responseData.message}`)
+        document.getElementById('plot').innerHTML = responseData.message
+      } else {
+        console.log(`Received response: ${responseData.message}`)
+        const plotHTML = responseData.results
+        let newPlotHTML = stylePlotHTML(plotHTML)
 
-      console.log(`Received response: ${newPlotHTML}`)
-
-      insertHTMLWithScripts('plot', newPlotHTML)
+        insertHTMLWithScripts('plot', newPlotHTML)
+      }
+    } else {
+      document.getElementById('plot').innerHTML = 'Network error'
+      console.error(`Error with response status: ${response.status}`)
     }
   } catch (error) {
-    document.getElementById('plot-loader').style.display = 'none'
-    console.error('Network error:', error)
+    document.getElementById('plot_loader').style.display = 'none'
+    document.getElementById('plot').innerHTML = 'Network error'
+    console.error('Error - plot.js - plot():', error)
   }
-  console.log('Started request…')
 }
 
 function insertHTMLWithScripts(containerId, html) {


### PR DESCRIPTION
**Comments:**
----------------
Standardized the result/error handling between APIs and .js
Does not have to be final result, just needed this for dev at least

palette_router: removed database user functions for the moment 
palette.js: refactored js to use try catch

**Test:**
---------
**Setup:**
  1. fetch branch
  2. build/run docker-compose
  3. go to site. 
  4. open browser console

**Steps:**
  1. From home, click palette
    - will see palette properties (bases, labels, shapes, etc)
    - will see 'Received response: Proc - Success' in console, or detailed error (enough to find location to work)
  2. click return to home
  3. from home, click plotter
  4. select layout and file, click single layout
    - will see plot graph
    - will see 'Received response: Proc - Plot generated successfully' in console, or detailed error
  5. click return to home
  6. click parser
    - will see graph data description
    - will see 'Received response: Graph description successfully fetched from processor.' in console, or detailed error

**Issue:**
----------
Closes #9 
