### PR TITLE
Parser: Display GitHub URL Contents

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ output/
 .dev/
 .vscode/
 ..vscode/
+.git/
 
 # package files
 config.json

--- a/src/codecarto/containers/processor/api/routers/parser_router.py
+++ b/src/codecarto/containers/processor/api/routers/parser_router.py
@@ -1,8 +1,204 @@
-from fastapi import APIRouter
+import httpx
+from fastapi import APIRouter, HTTPException
 
+# Create a router
 ParserRoute = APIRouter()
 
 
 @ParserRoute.get("/parse")
 async def parse():
     pass
+
+
+@ParserRoute.get("/handle_github_url")
+async def handle_github_url(github_url: str) -> dict:
+    try:
+        client = httpx.AsyncClient()
+        # check that the url is a github url
+        if "github.com" not in github_url:
+            raise HTTPException(
+                status_code=404,
+                detail={
+                    "proc_err_msg": "URL is not a valid GitHub URL",
+                    "github_url": github_url,
+                },
+            )
+
+        # Extract owner and repo from the URL
+        # Assuming the URL is like: https://github.com/owner/repo
+        parts = github_url.split("/")
+        if len(parts) < 5 or parts[2] != "github.com":
+            raise HTTPException(
+                status_code=404,
+                detail={
+                    "proc_err_msg": "Invalid GitHub URL format",
+                    "github_url": github_url,
+                },
+            )
+        owner, repo = parts[3], parts[4]
+
+        # get content from url
+        url_content: list[dict] = await read_github_content(github_url, owner, repo)
+        if not url_content:
+            raise HTTPException(
+                status_code=404,
+                detail={
+                    "proc_err_msg": "Empty file content received from GitHub",
+                    "github_url": github_url,
+                },
+            )
+        # url_content = await fetch_directory(github_url)
+        repo_contents = {
+            "package_owner": owner,
+            "package_name": repo,
+            "contents": {},
+        }
+        repo_contents["contents"]: dict = await parse_github_content(
+            url_content, owner, repo
+        )
+        if repo_contents:
+            return {
+                "status": "success",
+                "message": "Proc - Success",
+                "results": repo_contents,
+            }
+
+        else:
+            raise HTTPException(
+                status_code=404,
+                detail={
+                    "proc_err_msg": "Could not parse content returned from GitHub",
+                    "github_url": github_url,
+                },
+            )
+    except HTTPException as exc:
+        # Handle network errors
+        raise HTTPException(
+            status_code=exc.status_code,
+            detail={
+                "proc_err_msg": f'Error requesting GitHub URL: {exc.detail["proc_err_msg"]}',
+                "github_url": github_url,
+            },
+        ) from exc
+    except Exception as exc:
+        raise HTTPException(
+            status_code=500,
+            detail={
+                "proc_err_msg": "An error occurred while processing the GitHub URL",
+                "github_url": github_url,
+            },
+        ) from exc
+    finally:
+        await client.aclose()
+
+
+async def read_github_content(
+    url: str, owner: str, repo: str, path: str = ""
+) -> list[dict]:
+    try:
+        client = httpx.AsyncClient()
+
+        # Construct the API URL
+        api_url = f"https://api.github.com/repos/{owner}/{repo}/contents/{path}"
+
+        headers = {
+            "Accept": "application/vnd.github.v3+json",
+            # Uncomment and set your token if you have one
+            # "Authorization": "your token here",
+        }
+
+        response = await client.get(api_url, headers=headers, follow_redirects=False)
+
+        if response.status_code == 200:
+            json_data = response.json()
+            if not json_data:
+                raise HTTPException(
+                    status_code=404,
+                    detail={
+                        "proc_err_msg": "No data returned from GitHub API",
+                        "url": url,
+                        "api_url": api_url,
+                    },
+                )
+
+            # Remove unnecessary data from the response
+            for item in json_data:
+                item.pop("sha", None)
+                item.pop("url", None)
+                item.pop("git_url", None)
+                item.pop("_links", None)
+
+            return json_data
+        else:
+            if response.status_code == 404:
+                raise HTTPException(
+                    status_code=404,
+                    detail={
+                        "proc_err_msg": "GitHub API returned 404",
+                        "url": url,
+                        "api_url": api_url,
+                    },
+                )
+            else:
+                raise HTTPException(
+                    status_code=500,
+                    detail={
+                        "proc_err_msg": "GitHub API returned an error",
+                        "url": url,
+                        "api_url": api_url,
+                        "status_code": response.status_code,
+                    },
+                )
+    except httpx.RequestError as exc:
+        # Handle network errors
+        raise HTTPException(
+            status_code=500,
+            detail={
+                "proc_err_msg": "Error while attempting to set up request url & headers",
+                "url": url,
+                "api_url": api_url,
+            },
+        ) from exc
+
+
+async def parse_github_content(file_content, owner, repo) -> dict:
+    try:
+        # Check that the file content is a list
+        if not file_content or not isinstance(file_content, list):
+            raise HTTPException(
+                status_code=500,
+                detail={
+                    "proc_err_msg": "Invalid file content format",
+                    "file_content": file_content,
+                },
+            )
+
+        # Process directories
+        results = {}
+        directories: list = [item for item in file_content if item["type"] == "dir"]
+        files: list = [item for item in file_content if item["type"] == "file"]
+
+        for dir in directories:
+            dir_content = await read_github_content("", owner, repo, dir["path"])
+            parsed_dir_content = await parse_github_content(dir_content, owner, repo)
+            dir_name = dir["name"]
+            results[dir_name] = parsed_dir_content
+
+        # Process files
+        top_files = []
+        for file in files:
+            file_name = file["name"]
+            top_files.append(file_name)
+
+        if top_files:
+            results["files"] = top_files
+
+        return results
+    except Exception as exc:
+        raise HTTPException(
+            status_code=500,
+            detail={
+                "proc_err_msg": "Error when parsing GitHub content",
+                "file_content": file_content,
+            },
+        ) from exc

--- a/src/codecarto/containers/web/api/routers/parser_router.py
+++ b/src/codecarto/containers/web/api/routers/parser_router.py
@@ -1,19 +1,78 @@
-from fastapi import APIRouter, UploadFile, File, Request
+import httpx
+from fastapi import APIRouter, UploadFile, File, Request, HTTPException
 from fastapi.responses import JSONResponse
 from fastapi.templating import Jinja2Templates
 
-# Create a router and add the limiter to it
+
+# Create a router
 ParserRoute: APIRouter = APIRouter()
 pages = Jinja2Templates(directory="src/pages")
 html_page = "/parse/parse.html"
 
 PROC_PARSE_API_URL = "http://processor:2020/parser/parse"
+PROC_GITHUB_API_URL = "http://processor:2020/parser/handle_github_url"
 
 
 # Root page
 @ParserRoute.get("/")
 async def root(request: Request):
     return pages.TemplateResponse(html_page, {"request": request})
+
+
+@ParserRoute.get("/handle_github_url/")
+async def handle_github_url(github_url: str) -> dict:
+    # Call the processor container
+
+    # TODO: call the proc api to start it, will get a job id
+    # TODO: check the database every X secs on job id for results
+    # TODO: Temp work around to see if working
+    async with httpx.AsyncClient(timeout=60.0) as client:
+        try:
+            response = await client.get(
+                PROC_GITHUB_API_URL,
+                params={
+                    "github_url": github_url,
+                },
+            )
+            response.raise_for_status()
+            if not response.status_code == 200:
+                detail: dict = response.json()
+                detail["web_err_msg"] = "Could not fetch github contents from processor"
+                raise HTTPException(
+                    status_code=response.status_code, detail=response.json()
+                )
+            return response.json()
+        except httpx.RequestError as exc:
+            # Handle network errors
+            raise HTTPException(
+                status_code=500,
+                detail={
+                    "web_err_msg": "An error occurred while requesting",
+                    "github_url": github_url,
+                },
+            ) from exc
+        except httpx.HTTPStatusError as exc:
+            # Handle non-2xx responses
+            # Extract the actual error message from the response content
+            error_message = exc.response.json().get("detail", str(exc))
+            raise HTTPException(
+                status_code=exc.response.status_code,
+                detail={
+                    "web_err_msg": f"Error response from processor: {error_message}",
+                    "github_url": github_url,
+                },
+            ) from exc
+        except KeyError as exc:
+            # Handle missing 'results' key in response
+            raise HTTPException(
+                status_code=500,
+                detail={
+                    "web_err_msg": "Key 'results' not found in response",
+                    "github_url": github_url,
+                },
+            ) from exc
+        finally:
+            await client.aclose()
 
 
 @ParserRoute.get(
@@ -24,4 +83,6 @@ async def root(request: Request):
 async def parse(
     source_files: list[UploadFile] = File(...), language: str = "Python"
 ) -> dict[str, str]:
+    # check that it's a .py file
+    # pass the files to the processor api
     pass

--- a/src/codecarto/containers/web/src/pages/base.css
+++ b/src/codecarto/containers/web/src/pages/base.css
@@ -3,12 +3,17 @@ body {
   font-family: 'Calibri', sans-serif;
   background-color: #2c221a;
   color: #e1c48f;
+  font-size: 16px;
+}
+hr {
+  width: 75%;
+  border: 1px solid #e1c48f;
+  margin-left: auto;
 }
 /* selection lists */
 select {
   height: 30px;
   width: 200px;
-  font-size: 16px;
   background-color: #e5ca8f;
   border: none;
   border-radius: 5px;
@@ -26,13 +31,13 @@ option {
 button {
   height: 30px;
   width: 200px;
-  font-size: 16px;
   background-color: #d7b073;
   border: none;
   border-radius: 5px;
   margin: 5px;
   outline: none;
   color: rgb(24, 22, 21);
+  font-size: 16px;
 }
 button:hover {
   background-color: #e8dbad;
@@ -40,6 +45,7 @@ button:hover {
 button:disabled {
   background-color: #b1987e;
 }
+/* collapsibles */
 button.collapsible {
   height: 40px;
   width: 300px;
@@ -48,10 +54,11 @@ button.collapsible {
   outline: none;
   margin: 0px;
   padding: 10px;
-  font-size: 18px;
-  text-align: left;
+  margin-top: 0;
   background-color: #d7b073;
   color: rgb(24, 22, 21);
+  font-size: 18px;
+  text-align: left;
   cursor: pointer;
 }
 button.collapsible.active,
@@ -61,10 +68,18 @@ button.collapsible:hover {
 div.content {
   display: none;
   width: 400px;
-  padding: 10px;
+  padding: 5px;
+  margin-bottom: -14px;
+  box-sizing: border-box;
+  border: solid 1px #e8dbad;
   font-size: 16px;
-  background-color: #d7b073;
-  color: rgb(24, 22, 21);
+}
+div.content > div.content {
+  width: 300px;
+  margin-bottom: 5px;
+}
+ul {
+  list-style-type: none;
 }
 
 /* load spinners */

--- a/src/codecarto/containers/web/src/pages/base.html
+++ b/src/codecarto/containers/web/src/pages/base.html
@@ -7,6 +7,7 @@
     <title>CodeCartographer</title>
     <!-- External Scripts -->
     <script src="/pages/reload.js"></script>
+    <script src="/pages/base.js"></script>
     <!-- Internal Styles -->
     <link rel="stylesheet" href="/pages/base.css" />
   </head>

--- a/src/codecarto/containers/web/src/pages/base.js
+++ b/src/codecarto/containers/web/src/pages/base.js
@@ -1,0 +1,50 @@
+function displayError(elementId, message, consoleMessage) {
+  document.getElementById(elementId).innerHTML = message
+  if (consoleMessage) {
+    console.error(consoleMessage, message)
+  }
+}
+
+function convertListToButtons(data) {
+  // Convert <ul><li> structures to collapsible button structures
+  let result = ''
+  const parser = new DOMParser()
+  const dom = parser.parseFromString(data, 'text/html')
+  const items = dom.querySelectorAll('ul > li')
+
+  items.forEach(item => {
+    const key = item.querySelector('strong')
+      ? item.querySelector('strong').textContent
+      : item.textContent
+    const nestedUl = item.querySelector('ul')
+
+    if (nestedUl) {
+      let nestedContent = ''
+      nestedUl.querySelectorAll('li').forEach(li => {
+        nestedContent += `${li.innerHTML}`
+      })
+      result += `<button class="collapsible">${key}</button>`
+      result += `<div class="content">${nestedContent}</div>`
+    } else {
+      result += item.outerHTML
+    }
+  })
+
+  return result
+}
+
+function attachCollapsibleListeners() {
+  var coll = document.getElementsByClassName('collapsible')
+  var i
+  for (i = 0; i < coll.length; i++) {
+    coll[i].addEventListener('click', function () {
+      this.classList.toggle('active')
+      var content = this.nextElementSibling
+      if (content.style.display === 'block') {
+        content.style.display = 'none'
+      } else {
+        content.style.display = 'block'
+      }
+    })
+  }
+}

--- a/src/codecarto/containers/web/src/pages/palette/palette.js
+++ b/src/codecarto/containers/web/src/pages/palette/palette.js
@@ -11,25 +11,7 @@ async function getPalette() {
       } else {
         console.log(`Received response: ${responseData.message}`)
         const data = responseData.results
-
-        // Create a string variable with the content of the <div>
-        let content = ''
-        for (const [key, value] of Object.entries(data)) {
-          // check if value is a dictionary
-          if (typeof value === 'object') {
-            content += `<button class="collapsible">${key}</button>`
-            content += `<div class="content">`
-            // if so, iterate through the dictionary
-            for (const [k, v] of Object.entries(value)) {
-              // Concatenating key-value pairs
-              content += `${k}: ${v}<br>`
-            }
-            // remove last <br>
-            content = content.slice(0, -4)
-            content += `</div><br>`
-          }
-        }
-        // Update the content of the <div>
+        const content = handleContents(data)
         document.getElementById('pal_data').innerHTML = content
         attachCollapsibleListeners()
       }
@@ -43,18 +25,30 @@ async function getPalette() {
   }
 }
 
-function attachCollapsibleListeners() {
-  var coll = document.getElementsByClassName('collapsible')
-  var i
-  for (i = 0; i < coll.length; i++) {
-    coll[i].addEventListener('click', function () {
-      this.classList.toggle('active')
-      var content = this.nextElementSibling
-      if (content.style.display === 'block') {
-        content.style.display = 'none'
-      } else {
-        content.style.display = 'block'
+function handleContents(data) {
+  let content = ''
+
+  for (const [key, value] of Object.entries(data)) {
+    if (typeof value === 'object') {
+      // If the value is an object (directory)
+      content += `<button class="collapsible">${key}</button>`
+      content += `<div class="content">`
+      for (const [k, v] of Object.entries(value)) {
+        // Concatenating key-value pairs
+        content += `${k}: ${v}<br>`
       }
-    })
+      // remove last <br>
+      content = content.slice(0, -4)
+      content += `</div><br>`
+    } else {
+      // If the value is not an object (file)
+      if (key === 'file') {
+        content += `<div>${value}</div><br>`
+      } else {
+        content += `<div>${key}</div><br>`
+      }
+    }
   }
+
+  return content
 }

--- a/src/codecarto/containers/web/src/pages/parse/parse.css
+++ b/src/codecarto/containers/web/src/pages/parse/parse.css
@@ -3,3 +3,10 @@
 #graph_desc {
   font-size: 20px;
 }
+#githubUrl {
+  width: 500px;
+  height: 20px;
+  border-radius: 5px;
+  padding-left: 5px;
+  margin-left: 5px;
+}

--- a/src/codecarto/containers/web/src/pages/parse/parse.html
+++ b/src/codecarto/containers/web/src/pages/parse/parse.html
@@ -12,13 +12,29 @@
 <!-- BODY -->
 <main>
   <!-- Parser Desc -->
-  <section id="parser-desc">
+  <section id="parser_desc">
     <h2 style="margin-top: -20px">Parser</h2>
     <button onclick="window.location.href = '/'">Return Home</button>
   </section>
+  <!-- Parser github URL -->
+  <section id="github_url">
+    <form id="githubForm">
+      <h3 for="githubUrl">GitHub Repository URL:</h3>
+      <input type="text" id="githubUrl" name="githubUrl" /><br />
+      <button id="githubUrl_btn" type="button" onclick="handleGithubURL()">
+        Submit
+      </button>
+      <div id="github_loader" class="loader" style="display: none">
+        Loading ...
+      </div>
+    </form>
+    <div id="url_content"></div>
+  </section>
   <br /><br />
+  <hr />
+  <br />
   <!-- Parser Display -->
-  <section id="parser-display">
+  <section id="parser_display">
     <div id="graph_desc"></div>
   </section>
 </main>

--- a/src/codecarto/containers/web/src/pages/parse/parse.js
+++ b/src/codecarto/containers/web/src/pages/parse/parse.js
@@ -1,44 +1,177 @@
+/**
+ * Attach event listeners to the collapsible buttons.
+ */
 async function getGraphDesc() {
-  var href_line = `/polygraph/get_graph_desc`
   try {
+    // Get the graph description from the backend
+    const href_line = `/polygraph/get_graph_desc`
     const response = await fetch(href_line)
-    console.log(`Received response status: ${response.status}`)
     const responseData = await response.json()
-    console.log(`Received response data: ${responseData}`)
 
     if (response.ok) {
-      if (responseData.error) {
-        console.log(`Received response error: ERROR WITH RESPONSE DATA`)
-        document.getElementById('graph_desc').innerHTML =
-          'Could not display graph description'
+      // Check if the response is an error from the backend
+      if (responseData.status === 'error') {
+        displayError(
+          'graph_desc',
+          responseData.message,
+          `Error with response data: `
+        )
       } else {
-        console.log(`Getting graph_desc`)
-        const graph_desc = responseData.graph_desc
-        console.log(`Checking graph_desc is object: ${graph_desc}`)
-        console.log(`Parsing graph_desc to HTML`)
+        // Convert the data to html and display it
+        const graph_desc = responseData.results
         let graphDescHTML =
           '<div id="graph_desc">The graph data (JSON obj) needs to structured as the following:'
         graphDescHTML += graphDescToHTML(graph_desc)
         graphDescHTML += '</div>'
         document.getElementById('graph_desc').innerHTML = graphDescHTML
       }
+    } else {
+      displayError(
+        'graph_desc',
+        'API Error',
+        `Error with response status: ${response.status}`
+      )
     }
   } catch (error) {
-    document.getElementById('graph_desc').innerHTML = 'Network error'
-    console.error('Network error:', error)
+    displayError(
+      'graph_desc',
+      'JS Error',
+      `Error - parse.js - getGraphDesc(): ${error}`
+    )
   }
-  console.log('Started request…')
 }
 
+/**
+ * Convert the given graph description object to HTML.
+ * @param {Object} obj - The graph description object.
+ * @return {string} - The formatted HTML content.
+ */
 function graphDescToHTML(obj) {
+  // Check if the object is null
+  let html = ''
   if (typeof obj !== 'object') {
-    return `<span>${obj}</span>`
+    html += `<span>Invalid format: ${obj}</span>`
+  } else {
+    // Iterate through the object
+    html = `<ul>`
+    for (const [key, value] of Object.entries(obj)) {
+      html += `<li><strong>${key}</strong>: ${graphDescToHTML(value)}</li>`
+    }
+    html += `</ul>`
   }
-
-  let html = `<ul>`
-  for (const [key, value] of Object.entries(obj)) {
-    html += `<li><strong>${key}</strong>: ${graphDescToHTML(value)}</li>`
-  }
-  html += `</ul>`
+  // Return the html
   return html
+}
+
+/**
+ * Get the directories and files from the given GitHub URL.
+ */
+async function handleGithubURL() {
+  // Check if the url input is blank or not
+  if (document.getElementById('githubUrl').value === '') {
+    document.getElementById('url_content').innerHTML = 'Please enter a URL'
+    return
+  } else {
+    try {
+      // Get the url from the input, and encode it
+      document.getElementById('url_content').innerHTML = ''
+      document.getElementById('github_loader').style.display = 'inline'
+      let githubUrl = document.getElementById('githubUrl').value
+      if (githubUrl[githubUrl.length - 1] !== '/') {
+        githubUrl += '/'
+      }
+      const encodedGithubUrl = encodeURIComponent(githubUrl)
+      const href_line = `/parser/handle_github_url?github_url=${encodedGithubUrl}`
+      const response = await fetch(href_line)
+      const responseData = await response.json()
+
+      if (response.ok) {
+        // Check if the response is an error from the backend
+        if (responseData.status === 'error') {
+          displayError(
+            'url_content',
+            responseData.message,
+            `Error with response data: ${responseData.detail}`
+          )
+        } else {
+          // Refactor the data and display it
+          const data = responseData.results
+          const refactoredData = refactorGitHubData(data)
+          document.getElementById('url_content').innerHTML = refactoredData
+          attachCollapsibleListeners()
+        }
+      } else {
+        displayError(
+          'url_content',
+          'API Error',
+          `Error with response status: ${response.status}`
+        )
+      }
+    } catch (error) {
+      displayError(
+        'url_content',
+        'JS Error',
+        `Error - parse.js - handleGithubURL(): ${error}`
+      )
+    } finally {
+      document.getElementById('github_loader').style.display = 'none'
+    }
+  }
+}
+
+/**
+ * Attach collapsible listeners to the collapsible buttons.
+ * @param {Object} data - The GitHub data to be converted.
+ * @return {string} - The formatted HTML content.
+ */
+function refactorGitHubData(data) {
+  // Check if the data is null
+  let html = ''
+  if (!data) {
+    html += `<span>There is no content to display</span>`
+  } else {
+    // Extract the owner, repo, and contents from the data
+    const dataOwner = data.package_owner
+    const dataRepo = data.package_name
+    const dataContents = data.contents
+    const dataDict = { contents: dataContents }
+    const contentHtml = handleGitHubData(dataDict)
+    // Add package owner and name to the html
+    html += `<pre>`
+    html += `Package Owner: ${dataOwner}<br>`
+    html += `Package Name: ${dataRepo}`
+    html += `</pre>`
+    html += `${contentHtml}`
+  }
+  // Return the html
+  return html
+}
+
+/**
+ * Create a collapsible button structure from the given GitHub data.
+ * @param {Object} data - The GitHub data to be converted.
+ * @param {boolean} nested - Whether the data is nested or not.
+ * @return {string} - The formatted HTML content.
+ */
+function handleGitHubData(data, nested = false) {
+  // Iterate through the data
+  let content = ''
+  for (const [key, value] of Object.entries(data)) {
+    if (typeof value === 'object') {
+      // If the key is "files", it's a list of filenames
+      if (key === 'files') {
+        for (const file of value) {
+          content += `<div>${file}</div>`
+        }
+      } else {
+        // Else, it's a directory
+        content += `<button class="collapsible">${key}</button>`
+        content += `<div class="content">`
+        content += handleGitHubData(value, nested) // Recursive call for nested directories
+        content += `</div>`
+      }
+    }
+  }
+  // Return the content
+  return content
 }

--- a/src/codecarto/containers/web/src/pages/reload.js
+++ b/src/codecarto/containers/web/src/pages/reload.js
@@ -44,7 +44,7 @@ const filesToMonitor = [
   '/pages/plot/plot.js',
   '/pages/base.css',
   '/pages/base.html',
-  '/pages/reload.js',
+  '/pages/base.js',
 ]
 
 monitorFiles(filesToMonitor)


### PR DESCRIPTION
Updated web/proc container's parser_router to receive a github html string and return a json object of directories and files

Setup:
1. fetch branch
2. run/build docker
3. open site

Test:
1. Click Parser
2. Input a valid public github url
3. Click Submit
	- will see loading message
4. Wait for fetch to be done
	- once loaded, will not see loading message
	- will see package owner, repo name
	- will see collapsible 'contents' container with directories (if any) and files (if any)
5. Input an invalid github url (ex. https://github.com/ThisTest/Testingtestsasdf)
	- contents will dissappear
	- "Loading..." will reappear
6. Wait for fetch to be done
	- once loaded, will not see loading message
	- will see API error (can look in browser console Network tab for details on 404 error)

Closes #1