### PR TITLE
C parser: stub POSIX headers, platform-skip, diagnostics, frontend warning cue

### DIFF
--- a/codecarto/data/c_stubs/dirent.h
+++ b/codecarto/data/c_stubs/dirent.h
@@ -1,0 +1,21 @@
+/* Syntax-level stub for parsing only — not a real libc. See c_parser.py. */
+#ifndef _CODECARTO_STUB_DIRENT_H
+#define _CODECARTO_STUB_DIRENT_H
+
+#include <sys/types.h>
+
+typedef struct DIR DIR;
+
+struct dirent {
+    ino_t d_ino;
+    char  d_name[256];
+};
+
+DIR *opendir(const char *name);
+struct dirent *readdir(DIR *dirp);
+int closedir(DIR *dirp);
+void rewinddir(DIR *dirp);
+long telldir(DIR *dirp);
+void seekdir(DIR *dirp, long loc);
+
+#endif

--- a/codecarto/data/c_stubs/fcntl.h
+++ b/codecarto/data/c_stubs/fcntl.h
@@ -1,0 +1,27 @@
+/* Syntax-level stub for parsing only — not a real libc. See c_parser.py. */
+#ifndef _CODECARTO_STUB_FCNTL_H
+#define _CODECARTO_STUB_FCNTL_H
+
+#include <sys/types.h>
+
+#define O_RDONLY   0x0000
+#define O_WRONLY   0x0001
+#define O_RDWR     0x0002
+#define O_CREAT    0x0040
+#define O_EXCL     0x0080
+#define O_TRUNC    0x0200
+#define O_APPEND   0x0400
+#define O_NONBLOCK 0x0800
+#define O_CLOEXEC  0x80000
+
+#define F_DUPFD 0
+#define F_GETFD 1
+#define F_SETFD 2
+#define F_GETFL 3
+#define F_SETFL 4
+
+int open(const char *path, int flags, ...);
+int creat(const char *path, mode_t mode);
+int fcntl(int fd, int cmd, ...);
+
+#endif

--- a/codecarto/data/c_stubs/pthread.h
+++ b/codecarto/data/c_stubs/pthread.h
@@ -1,0 +1,44 @@
+/* Syntax-level stub for parsing only — not a real libc. See c_parser.py. */
+#ifndef _CODECARTO_STUB_PTHREAD_H
+#define _CODECARTO_STUB_PTHREAD_H
+
+typedef unsigned long pthread_t;
+typedef struct { int __opaque[8]; } pthread_mutex_t;
+typedef struct { int __opaque[8]; } pthread_cond_t;
+typedef struct { int __opaque[4]; } pthread_attr_t;
+typedef struct { int __opaque[4]; } pthread_mutexattr_t;
+typedef struct { int __opaque[4]; } pthread_condattr_t;
+typedef unsigned long pthread_key_t;
+typedef struct { int __opaque[8]; } pthread_once_t;
+typedef struct { int __opaque[8]; } pthread_rwlock_t;
+
+#define PTHREAD_MUTEX_INITIALIZER  {{0}}
+#define PTHREAD_COND_INITIALIZER   {{0}}
+#define PTHREAD_ONCE_INIT          {{0}}
+
+int pthread_create(pthread_t *thread, const pthread_attr_t *attr,
+                    void *(*start_routine)(void *), void *arg);
+int pthread_join(pthread_t thread, void **retval);
+int pthread_detach(pthread_t thread);
+pthread_t pthread_self(void);
+int pthread_equal(pthread_t a, pthread_t b);
+void pthread_exit(void *retval);
+
+int pthread_mutex_init(pthread_mutex_t *mutex, const pthread_mutexattr_t *attr);
+int pthread_mutex_destroy(pthread_mutex_t *mutex);
+int pthread_mutex_lock(pthread_mutex_t *mutex);
+int pthread_mutex_trylock(pthread_mutex_t *mutex);
+int pthread_mutex_unlock(pthread_mutex_t *mutex);
+
+int pthread_cond_init(pthread_cond_t *cond, const pthread_condattr_t *attr);
+int pthread_cond_destroy(pthread_cond_t *cond);
+int pthread_cond_wait(pthread_cond_t *cond, pthread_mutex_t *mutex);
+int pthread_cond_signal(pthread_cond_t *cond);
+int pthread_cond_broadcast(pthread_cond_t *cond);
+
+int pthread_once(pthread_once_t *once_control, void (*init_routine)(void));
+int pthread_key_create(pthread_key_t *key, void (*destructor)(void *));
+int pthread_setspecific(pthread_key_t key, const void *value);
+void *pthread_getspecific(pthread_key_t key);
+
+#endif

--- a/codecarto/data/c_stubs/stddef.h
+++ b/codecarto/data/c_stubs/stddef.h
@@ -1,0 +1,15 @@
+/* Fallback stub — only used if libclang's own resource-dir stddef.h isn't
+ * found (parse-time syntax aid; not a real libc). See c_parser.py. */
+#ifndef _CODECARTO_STUB_STDDEF_H
+#define _CODECARTO_STUB_STDDEF_H
+
+#ifndef __cplusplus
+typedef int wchar_t;
+#endif
+
+typedef unsigned long size_t;
+typedef long          ptrdiff_t;
+#define NULL ((void *)0)
+#define offsetof(type, member) ((size_t)&((type *)0)->member)
+
+#endif

--- a/codecarto/data/c_stubs/stdint.h
+++ b/codecarto/data/c_stubs/stdint.h
@@ -1,0 +1,29 @@
+/* Fallback stub — only used if libclang's own resource-dir stdint.h isn't
+ * found (parse-time syntax aid; not a real libc). See c_parser.py. */
+#ifndef _CODECARTO_STUB_STDINT_H
+#define _CODECARTO_STUB_STDINT_H
+
+typedef signed char        int8_t;
+typedef unsigned char       uint8_t;
+typedef short               int16_t;
+typedef unsigned short      uint16_t;
+typedef int                 int32_t;
+typedef unsigned int        uint32_t;
+typedef long long           int64_t;
+typedef unsigned long long  uint64_t;
+
+typedef long long           intptr_t;
+typedef unsigned long long  uintptr_t;
+typedef long long           intmax_t;
+typedef unsigned long long  uintmax_t;
+
+typedef int8_t   int_least8_t;
+typedef uint8_t  uint_least8_t;
+typedef int16_t  int_least16_t;
+typedef uint16_t uint_least16_t;
+typedef int32_t  int_least32_t;
+typedef uint32_t uint_least32_t;
+typedef int64_t  int_least64_t;
+typedef uint64_t uint_least64_t;
+
+#endif

--- a/codecarto/data/c_stubs/strings.h
+++ b/codecarto/data/c_stubs/strings.h
@@ -1,0 +1,14 @@
+/* Syntax-level stub for parsing only — not a real libc. See c_parser.py. */
+#ifndef _CODECARTO_STUB_STRINGS_H
+#define _CODECARTO_STUB_STRINGS_H
+
+#include <sys/types.h>
+
+int strcasecmp(const char *a, const char *b);
+int strncasecmp(const char *a, const char *b, size_t n);
+int bcmp(const void *a, const void *b, size_t n);
+void bcopy(const void *src, void *dst, size_t n);
+void bzero(void *s, size_t n);
+int ffs(int i);
+
+#endif

--- a/codecarto/data/c_stubs/sys/stat.h
+++ b/codecarto/data/c_stubs/sys/stat.h
@@ -1,0 +1,61 @@
+/* Syntax-level stub for parsing only — not a real libc. See c_parser.py. */
+#ifndef _CODECARTO_STUB_SYS_STAT_H
+#define _CODECARTO_STUB_SYS_STAT_H
+
+#include <sys/types.h>
+
+#define S_IFMT   0170000
+#define S_IFDIR  0040000
+#define S_IFCHR  0020000
+#define S_IFBLK  0060000
+#define S_IFREG  0100000
+#define S_IFIFO  0010000
+#define S_IFLNK  0120000
+#define S_IFSOCK 0140000
+
+#define S_ISDIR(m)  (((m) & S_IFMT) == S_IFDIR)
+#define S_ISCHR(m)  (((m) & S_IFMT) == S_IFCHR)
+#define S_ISBLK(m)  (((m) & S_IFMT) == S_IFBLK)
+#define S_ISREG(m)  (((m) & S_IFMT) == S_IFREG)
+#define S_ISFIFO(m) (((m) & S_IFMT) == S_IFIFO)
+#define S_ISLNK(m)  (((m) & S_IFMT) == S_IFLNK)
+#define S_ISSOCK(m) (((m) & S_IFMT) == S_IFSOCK)
+
+#define S_IRUSR 0400
+#define S_IWUSR 0200
+#define S_IXUSR 0100
+#define S_IRWXU 0700
+#define S_IRGRP 0040
+#define S_IWGRP 0020
+#define S_IXGRP 0010
+#define S_IRWXG 0070
+#define S_IROTH 0004
+#define S_IWOTH 0002
+#define S_IXOTH 0001
+#define S_IRWXO 0007
+
+struct stat {
+    dev_t   st_dev;
+    ino_t   st_ino;
+    mode_t  st_mode;
+    nlink_t st_nlink;
+    uid_t   st_uid;
+    gid_t   st_gid;
+    dev_t   st_rdev;
+    off_t   st_size;
+    blksize_t st_blksize;
+    blkcnt_t  st_blocks;
+    time_t  st_atime;
+    time_t  st_mtime;
+    time_t  st_ctime;
+};
+
+int stat(const char *path, struct stat *buf);
+int fstat(int fd, struct stat *buf);
+int lstat(const char *path, struct stat *buf);
+int chmod(const char *path, mode_t mode);
+int fchmod(int fd, mode_t mode);
+int mkdir(const char *path, mode_t mode);
+int umask(int mask);
+
+#endif

--- a/codecarto/data/c_stubs/sys/time.h
+++ b/codecarto/data/c_stubs/sys/time.h
@@ -1,0 +1,21 @@
+/* Syntax-level stub for parsing only — not a real libc. See c_parser.py. */
+#ifndef _CODECARTO_STUB_SYS_TIME_H
+#define _CODECARTO_STUB_SYS_TIME_H
+
+#include <sys/types.h>
+
+struct timeval {
+    time_t      tv_sec;
+    suseconds_t tv_usec;
+};
+
+struct timezone {
+    int tz_minuteswest;
+    int tz_dsttime;
+};
+
+int gettimeofday(struct timeval *tv, struct timezone *tz);
+int settimeofday(const struct timeval *tv, const struct timezone *tz);
+int utimes(const char *filename, const struct timeval times[2]);
+
+#endif

--- a/codecarto/data/c_stubs/sys/types.h
+++ b/codecarto/data/c_stubs/sys/types.h
@@ -1,0 +1,23 @@
+/* Syntax-level stub for parsing only — not a real libc. See c_parser.py. */
+#ifndef _CODECARTO_STUB_SYS_TYPES_H
+#define _CODECARTO_STUB_SYS_TYPES_H
+
+#include <stdint.h>
+
+typedef long      ssize_t;
+typedef int        pid_t;
+typedef unsigned int uid_t;
+typedef unsigned int gid_t;
+typedef unsigned int mode_t;
+typedef long       off_t;
+typedef long       suseconds_t;
+typedef long       useconds_t;
+typedef unsigned long dev_t;
+typedef unsigned long ino_t;
+typedef unsigned long nlink_t;
+typedef long       blksize_t;
+typedef long       blkcnt_t;
+typedef long       time_t;
+typedef unsigned long socklen_t;
+
+#endif

--- a/codecarto/data/c_stubs/sys/wait.h
+++ b/codecarto/data/c_stubs/sys/wait.h
@@ -1,0 +1,20 @@
+/* Syntax-level stub for parsing only — not a real libc. See c_parser.py. */
+#ifndef _CODECARTO_STUB_SYS_WAIT_H
+#define _CODECARTO_STUB_SYS_WAIT_H
+
+#include <sys/types.h>
+
+#define WNOHANG   1
+#define WUNTRACED 2
+
+#define WIFEXITED(s)   (((s) & 0x7f) == 0)
+#define WEXITSTATUS(s) (((s) >> 8) & 0xff)
+#define WIFSIGNALED(s) (((s) & 0x7f) != 0)
+#define WTERMSIG(s)    ((s) & 0x7f)
+#define WIFSTOPPED(s)  (((s) & 0xff) == 0x7f)
+#define WSTOPSIG(s)    (((s) >> 8) & 0xff)
+
+pid_t wait(int *status);
+pid_t waitpid(pid_t pid, int *status, int options);
+
+#endif

--- a/codecarto/data/c_stubs/unistd.h
+++ b/codecarto/data/c_stubs/unistd.h
@@ -1,0 +1,46 @@
+/* Syntax-level stub for parsing only — not a real libc. See c_parser.py.
+ * Pulls in the type definitions most POSIX code expects transitively from
+ * <unistd.h>, so downstream "unknown type name" cascades (uint32_t, ssize_t,
+ * pid_t, ...) resolve even when the real system header isn't available. */
+#ifndef _CODECARTO_STUB_UNISTD_H
+#define _CODECARTO_STUB_UNISTD_H
+
+#include <stdint.h>
+#include <sys/types.h>
+
+#define STDIN_FILENO  0
+#define STDOUT_FILENO 1
+#define STDERR_FILENO 2
+
+#define SEEK_SET 0
+#define SEEK_CUR 1
+#define SEEK_END 2
+
+#define F_OK 0
+#define R_OK 4
+#define W_OK 2
+#define X_OK 1
+
+ssize_t read(int fd, void *buf, size_t count);
+ssize_t write(int fd, const void *buf, size_t count);
+int     close(int fd);
+off_t   lseek(int fd, off_t offset, int whence);
+int     access(const char *path, int mode);
+int     unlink(const char *path);
+int     rmdir(const char *path);
+int     chdir(const char *path);
+char   *getcwd(char *buf, size_t size);
+pid_t   fork(void);
+pid_t   getpid(void);
+pid_t   getppid(void);
+int     execv(const char *path, char *const argv[]);
+int     execvp(const char *file, char *const argv[]);
+unsigned int sleep(unsigned int seconds);
+int     usleep(unsigned int usec);
+int     pipe(int fd[2]);
+int     dup(int fd);
+int     dup2(int oldfd, int newfd);
+long    sysconf(int name);
+int     isatty(int fd);
+
+#endif

--- a/codecarto/services/c_parser_service.py
+++ b/codecarto/services/c_parser_service.py
@@ -157,10 +157,10 @@ class CParserService:
                 status_code=404,
             )
 
-        c_files = sorted(
+        all_files = sorted(
             list(dir_path.rglob("*.c")) + list(dir_path.rglob("*.h"))
         )
-        if not c_files:
+        if not all_files:
             raise CodeCartoException(
                 source="CParserService.parse_directory",
                 params={"path": path},
@@ -168,11 +168,35 @@ class CParserService:
                 status_code=404,
             )
 
+        # Without a compile_commands.json we have no way to know which
+        # platform variant was actually meant to build, so every compat
+        # shim for every OS would otherwise get parsed unconditionally
+        # (e.g. git ships compat/apple-*, compat/mingw.c, compat/solaris/*
+        # that are never compiled together). Skip known single-platform
+        # files rather than let them parse-with-errors.
+        from codecarto.services.parsers.c_parser import is_platform_specific_path, default_parse_args
+
+        skipped_files = [
+            str(f.relative_to(dir_path)) for f in all_files
+            if is_platform_specific_path(f.relative_to(dir_path))
+        ]
+        skipped_set = set(skipped_files)
+        c_files = [f for f in all_files if str(f.relative_to(dir_path)) not in skipped_set]
+
         if max_files:
             c_files = c_files[:max_files]
 
         try:
-            return parser.parse_files(c_files, cache_dir=cache_dir)
+            # Always include the project root, not just each file's own
+            # directory — multi-directory projects (e.g. git's builtin/*.c
+            # including the root-level builtin.h) need both on the path.
+            result = parser.parse_files(
+                c_files,
+                extra_args=default_parse_args(project_root=dir_path),
+                cache_dir=cache_dir,
+            )
+            result.setdefault("meta", {})["skipped_files"] = skipped_files
+            return result
         except Exception as exc:
             raise CodeCartoException(
                 source="CParserService.parse_directory",

--- a/codecarto/services/parsers/c_parser.py
+++ b/codecarto/services/parsers/c_parser.py
@@ -32,6 +32,58 @@ _LIBCLANG_CANDIDATES = [
     '/usr/lib/llvm-17/lib/libclang.so',
 ]
 
+# ── Parsing-without-a-build-system support ────────────────────────────────────
+# pip's libclang wheel ships no system/libc headers at all (not even the
+# compiler-provided stdint.h/stddef.h). Real-world C repos parsed file-by-file
+# (no compile_commands.json) hit constant "file not found" / "unknown type
+# name" cascades for POSIX headers. This stub set is a syntax-level aid only —
+# declarations exist so parsing doesn't cascade-fail, not a real libc.
+_STUB_DIR = Path(__file__).resolve().parent.parent.parent / "data" / "c_stubs"
+
+# Best-effort platform defines so '#ifdef'-gated POSIX declarations in target
+# code take a real branch against our stub headers instead of an undefined one.
+_PLATFORM_DEFINES = ['-D__linux__', '-D_GNU_SOURCE', '-D_DEFAULT_SOURCE']
+
+# Path fragments identifying source meant for exactly one non-default platform.
+# parse_directory has no compile_commands.json to tell it which variant is
+# actually built, so it would otherwise parse every platform's compat shim
+# unconditionally. These are skipped and reported in meta['skipped_files'].
+_PLATFORM_SPECIFIC_PATTERNS = (
+    'apple', 'darwin', 'macos', 'solaris', 'aix', 'hpux', 'irix', 'sunos',
+    'win32', 'mingw', 'msvc', 'winnt', 'os400', 'vms', 'nonstop', 'vcbuild',
+)
+
+
+def is_platform_specific_path(path: str | Path) -> bool:
+    """True if `path` looks like a single-platform compat shim (see above)."""
+    lowered = str(path).replace('\\', '/').lower()
+    return any(pat in lowered for pat in _PLATFORM_SPECIFIC_PATTERNS)
+
+
+def default_parse_args(project_root: Optional[str | Path] = None) -> list:
+    """Base clang args: stub headers, platform defines, and (if given) the
+    project root on the include path — needed because multi-directory C
+    projects commonly do `#include "foo.h"` expecting the build's `-I.`
+    root include, not just the including file's own directory."""
+    args = ['-std=c11', '-isystem', str(_STUB_DIR), *_PLATFORM_DEFINES]
+    if project_root:
+        args += [f'-I{project_root}']
+    return args
+
+
+# Backwards-compatible private alias used internally in this module.
+_default_parse_args = default_parse_args
+
+
+# ── Diagnostic classification ─────────────────────────────────────────────────
+def _classify_diagnostic(message: str) -> str:
+    msg = message.lower()
+    if 'file not found' in msg:
+        return 'missing_header'
+    if 'unknown type name' in msg or 'unknown type' in msg:
+        return 'unknown_type'
+    return 'other'
+
 
 def _get_clang():
     """Lazy-initialise the clang module and index. Raises ImportError if unavailable."""
@@ -284,7 +336,7 @@ class CParser:
         filepaths = [Path(f) for f in filepaths]
         target_stems = {f.stem for f in filepaths}
         in_target = _make_in_target(target_stems)
-        extra_args = extra_args or ['-std=c11']
+        extra_args = extra_args or _default_parse_args()
 
         if cache_dir:
             Path(cache_dir).mkdir(parents=True, exist_ok=True)
@@ -293,6 +345,9 @@ class CParser:
         edges: list = []
         edge_set: set = set()
         call_counts: dict = {}
+        diag_counts = {'missing_header': 0, 'unknown_type': 0, 'other': 0}
+        files_with_warnings: set = set()
+        worst_files: dict = {}
 
         for fpath in filepaths:
             args = extra_args + [f'-I{fpath.parent}']
@@ -309,6 +364,11 @@ class CParser:
             tu = idx.parse(str(fpath), args=args)
 
             errors = [d for d in tu.diagnostics if d.severity >= cindex.Diagnostic.Error]
+            if errors:
+                files_with_warnings.add(fpath.stem)
+                worst_files[fpath.stem] = len(errors)
+            for e in errors:
+                diag_counts[_classify_diagnostic(e.spelling)] += 1
             for e in errors[:3]:
                 logger.warning("libclang: %s", e.spelling)
 
@@ -319,6 +379,12 @@ class CParser:
                 cp.write_bytes(pickle.dumps({
                     'nodes': {k: v for k, v in nodes.items() if v['file'] == fpath.stem}
                 }))
+
+        # Flag nodes whose source file produced parser diagnostics, so the
+        # frontend can render a visual cue (see graph_renderer.ts).
+        for n in nodes.values():
+            if n['file'] in files_with_warnings:
+                n['has_parse_warning'] = True
 
         for fpath in filepaths:
             args = extra_args + [f'-I{fpath.parent}']
@@ -331,7 +397,15 @@ class CParser:
 
         _derive_type_edges(nodes, edges, edge_set)
 
-        return self._build_result(list(nodes.values()), edges, [f.name for f in filepaths])
+        diagnostics = {
+            **diag_counts,
+            'files_with_warnings': len(files_with_warnings),
+            'worst_files': sorted(worst_files.items(), key=lambda kv: -kv[1])[:5],
+        }
+
+        return self._build_result(
+            list(nodes.values()), edges, [f.name for f in filepaths], diagnostics
+        )
 
     def parse_compile_commands(
         self,
@@ -373,6 +447,9 @@ class CParser:
         edges: list = []
         edge_set: set = set()
         call_counts: dict = {}
+        diag_counts = {'missing_header': 0, 'unknown_type': 0, 'other': 0}
+        files_with_warnings: set = set()
+        worst_files: dict = {}
 
         for entry in cmds:
             fpath = Path(entry['file'])
@@ -386,9 +463,19 @@ class CParser:
             logger.info("Parsing %s", fpath.name)
             try:
                 tu = idx.parse(str(fpath), args=args)
+                errors = [d for d in tu.diagnostics if d.severity >= cindex.Diagnostic.Error]
+                if errors:
+                    files_with_warnings.add(fpath.stem)
+                    worst_files[fpath.stem] = len(errors)
+                for e in errors:
+                    diag_counts[_classify_diagnostic(e.spelling)] += 1
                 _pass1_declarations(tu, in_target, nodes, edges, edge_set, cindex)
             except Exception as exc:
                 logger.warning("Failed to parse %s: %s", fpath.name, exc)
+
+        for n in nodes.values():
+            if n['file'] in files_with_warnings:
+                n['has_parse_warning'] = True
 
         for entry in cmds:
             fpath = Path(entry['file'])
@@ -410,14 +497,27 @@ class CParser:
 
         _derive_type_edges(nodes, edges, edge_set)
 
+        diagnostics = {
+            **diag_counts,
+            'files_with_warnings': len(files_with_warnings),
+            'worst_files': sorted(worst_files.items(), key=lambda kv: -kv[1])[:5],
+        }
+
         return self._build_result(
             list(nodes.values()),
             edges,
             [Path(c['file']).name for c in cmds],
+            diagnostics,
         )
 
     @staticmethod
-    def _build_result(nodes: list, edges: list, file_names: list) -> dict:
+    def _build_result(
+        nodes: list,
+        edges: list,
+        file_names: list,
+        diagnostics: Optional[dict] = None,
+        skipped_files: Optional[list] = None,
+    ) -> dict:
         kind_counts: dict = {}
         for n in nodes:
             kind_counts[n['kind']] = kind_counts.get(n['kind'], 0) + 1
@@ -435,10 +535,12 @@ class CParser:
             'nodes': nodes,
             'edges': edges,
             'meta': {
-                'files':       file_names,
-                'node_count':  len(nodes),
-                'edge_count':  len(edges),
-                'kind_counts': kind_counts,
-                'edge_kinds':  edge_kind_counts,
+                'files':        file_names,
+                'node_count':   len(nodes),
+                'edge_count':   len(edges),
+                'kind_counts':  kind_counts,
+                'edge_kinds':   edge_kind_counts,
+                'diagnostics':  diagnostics or {},
+                'skipped_files': skipped_files or [],
             },
         }

--- a/docs/api.md
+++ b/docs/api.md
@@ -228,7 +228,21 @@ Parse a single C/H source file.
     "graph": {
       "nodes": [...],
       "edges": [...],
-      "meta": { "files": ["file"], "node_count": 12, "kind_counts": { "function": 3 } }
+      "meta": {
+        "files": ["file"],
+        "node_count": 12,
+        "edge_count": 8,
+        "kind_counts": { "function": 3 },
+        "edge_kinds": { "CALLS": 5, "FIELD_OF": 2, "POINTS_TO": 1 },
+        "diagnostics": {
+          "missing_header": 0,
+          "unknown_type": 0,
+          "other": 0,
+          "files_with_warnings": 0,
+          "worst_files": []
+        },
+        "skipped_files": []
+      }
     }
   }
 }
@@ -236,6 +250,17 @@ Parse a single C/H source file.
 
 > **Note:** `/c-parser/*` returns a legacy `{nodes, edges, meta}` dict. Use
 > `/parse/unified` with `.c`/`.h` extensions to get gJGF output compatible with D3/Gravis.
+
+When parsing without a `compile_commands.json` (i.e. `parse_files`/`parse_directory`,
+which backs `/c-parser/file`, `/c-parser/directory`, and `/c-parser/github`), each
+file is parsed standalone against a bundled set of stub POSIX headers
+(`codecarto/data/c_stubs/`) rather than the project's real build setup — see
+`codecarto/services/parsers/c_parser.py`. `meta.diagnostics` reports how often that
+fell short (missing headers, unknown types), and `meta.skipped_files` lists
+source files skipped because they target a single non-default platform (e.g.
+`compat/apple-*.c`, `compat/mingw.c`). Nodes whose source file produced parser
+errors are flagged `has_parse_warning: true` and rendered with a dashed amber
+border in the graph view.
 
 ---
 

--- a/docs/llm/next_steps/c_parser_phase3_compile_commands.md
+++ b/docs/llm/next_steps/c_parser_phase3_compile_commands.md
@@ -1,0 +1,65 @@
+# Next step: compile_commands-first parsing for the GitHub-example flow
+
+## Background
+
+The C parser (`codecarto/services/parsers/c_parser.py`) has two parse paths:
+
+- `parse_files` / `parse_directory` — walks every `.c`/`.h` under a directory
+  and parses each file standalone with only `-I<file's own dir>` and
+  `-I<project root>`. No real build context.
+- `parse_compile_commands` — parses using a real `compile_commands.json`,
+  which gives the *actual* include paths, defines, and language standard
+  used when the project was built.
+
+The GitHub-example UI flow (`CParserService.parse_github` →
+`parse_directory`) only ever uses the first path. Phase 1 (stub POSIX
+headers under `codecarto/data/c_stubs/`, platform-define injection, and
+skipping known single-platform compat files — see `c_parser.py`'s
+`default_parse_args()` / `is_platform_specific_path()`) meaningfully
+reduces the missing-header/unknown-type cascade for that path, but it's
+explicitly a best-effort syntax aid, not a real build.
+
+## What's still wrong without compile_commands.json
+
+- Project-specific generated headers (e.g. git's `command-list.h`, version
+  headers, or anything produced by `./configure`) are never found — they
+  don't exist until the project is actually built.
+- Per-file compiler flags (extra `-I`, feature-test macros like
+  `_FILE_OFFSET_BITS=64`, `-DNDEBUG`, vendor-specific pragmas) are invisible.
+- Stub-header type redefinition conflicts (observed: `time_t`/`size_t`
+  redefined differently between our POSIX stubs and whatever the project's
+  own compat headers pull in) — see the `diagnostics.other` count creep
+  after Phase 1's project-root `-I` change.
+
+## Proposed next step
+
+For repos fetched via `parse_github`, prefer a real `compile_commands.json`
+over naive directory walking, in priority order:
+
+1. **If the repo already ships one** (rare, but some do) — use it directly.
+2. **Generate one via a sandboxed build** — run `bear -- make` / `bear --
+   ./configure && make` (or `compiledb`) inside the extracted repo cache
+   (`~/.codecarto/cache/repos/{owner}-{repo}/src/`), capped by a timeout,
+   before falling back to `parse_directory` on failure. This requires:
+   - A sandboxed/ephemeral build environment (the current service runs
+     arbitrary `make`/`configure` from an arbitrary GitHub repo — this is a
+     real execution-of-untrusted-code concern and needs its own security
+     review, likely a container or restricted subprocess with no network
+     access and a hard CPU/time/disk budget).
+   - Graceful fallback to the current `parse_directory` path when the build
+     fails (missing build deps, no `Makefile`, Windows host can't run the
+     repo's build system, etc.) — this is the common case for most repos,
+     so Phase 1's stub-header approach remains the baseline, not a stopgap.
+3. **Surface which path was used** in `meta` (e.g. `meta['parse_mode'] =
+   'compile_commands' | 'directory_walk'`) so the frontend/legend can show
+   the user how much to trust the resulting graph's completeness.
+
+## Why this is its own phase
+
+Sandboxed arbitrary code execution is a materially different risk profile
+and engineering effort than the current "download zip, walk files, parse
+each standalone" flow — it deserves its own design/security pass rather
+than folding into the stub-header work. Phase 1 should remain in place
+regardless, since most repos won't have a usable build (no configure step
+documented, deps unavailable, cross-platform build systems that don't run
+on the host) and will always fall back to it.

--- a/web/src/features/graph/services/graph_renderer.ts
+++ b/web/src/features/graph/services/graph_renderer.ts
@@ -113,6 +113,17 @@ export class GraphRenderer {
   private static tooltipExtension: TooltipExtension | null = null;
   private static colorExtension: ColorExtension | null = null;
 
+  /** Deselected-state border colour — amber for nodes whose source file had
+   * parser diagnostics (see c_parser.py has_parse_warning), white otherwise. */
+  private static nodeBorderColor(d: GraphNode): string {
+    return d.has_parse_warning ? '#f5a623' : '#fff';
+  }
+
+  /** Deselected-state border dasharray — dashed for parse-warning nodes. */
+  private static nodeBorderDash(d: GraphNode): string | null {
+    return d.has_parse_warning ? '3,2' : null;
+  }
+
   /**
    * Render graph data using D3.js with enhanced interactions
    */
@@ -419,6 +430,21 @@ export class GraphRenderer {
       }
     };
 
+    // Edge-kind visual mapping. `label` carries the semantic edge kind
+    // (e.g. C parser: CALLS/FIELD_OF/POINTS_TO/ALIASES — see c_parser.py).
+    // Unrecognised kinds (other languages, untyped edges) fall through to
+    // the existing default styling untouched.
+    const EDGE_KIND_COLOR: Record<string, string> = {
+      CALLS:     '#e67e22',
+      FIELD_OF:  '#555e6e',
+      POINTS_TO: '#1abc9c',
+      ALIASES:   '#1abc9c',
+    };
+    const EDGE_KIND_DASH: Record<string, string> = {
+      POINTS_TO: '5,4',
+      ALIASES:   '8,4',
+    };
+
     // Draw edges with styling
     const link = g
       .append('g')
@@ -427,10 +453,13 @@ export class GraphRenderer {
       .data(edges)
       .enter()
       .append('line')
-      .attr('stroke', (d) => d.color || styling.edgeColor || '#999')
+      .attr('stroke', (d) => (d.color as string) || EDGE_KIND_COLOR[d.label as string] || styling.edgeColor || '#999')
       .attr('stroke-opacity', styling.edgeOpacity * 0.6)
-      .attr('stroke-width', styling.edgeWidth)
-      .attr('stroke-dasharray', getEdgeDashArray(styling.edgeStyle));
+      .attr('stroke-width', (d) => {
+        const weight = (d.weight as number) ?? 1;
+        return d.label === 'CALLS' ? styling.edgeWidth * Math.min(3, 0.5 + weight * 0.4) : styling.edgeWidth;
+      })
+      .attr('stroke-dasharray', (d) => getEdgeDashArray(styling.edgeStyle) ?? EDGE_KIND_DASH[d.label as string] ?? null);
 
     // Store references for radial menu callbacks (except zoom - will be set later)
     this.currentSvg = svg;
@@ -526,8 +555,12 @@ export class GraphRenderer {
       .attr('d', (d) => getNodePath(d.shape as string, styling.nodeSize * depthSizeMultiplier(d), d))
       .attr('fill', (d) => styling.nodeColorOverride || d.color || 'steelblue')
       .attr('fill-opacity', styling.nodeOpacity)
-      .attr('stroke', '#fff')
-      .attr('stroke-width', styling.nodeBorderWidth);
+      // Parser diagnostics (e.g. C: missing header / unknown type in this
+      // node's source file — see c_parser.py has_parse_warning) get a
+      // dashed amber border instead of the default solid white.
+      .attr('stroke', (d) => this.nodeBorderColor(d))
+      .attr('stroke-width', styling.nodeBorderWidth)
+      .attr('stroke-dasharray', (d) => this.nodeBorderDash(d));
 
     // Add interaction handlers to node groups
     const node = nodeGroup
@@ -539,8 +572,9 @@ export class GraphRenderer {
         if (selectedNodes.has(d)) {
           selectedNodes.delete(d);
           path
-            .attr('stroke', '#fff')
-            .attr('stroke-width', styling.nodeBorderWidth);
+            .attr('stroke', this.nodeBorderColor(d))
+            .attr('stroke-width', styling.nodeBorderWidth)
+            .attr('stroke-dasharray', this.nodeBorderDash(d));
         } else {
           if (!event.ctrlKey && !event.metaKey) {
             // Clear other selections if not multi-select
@@ -548,8 +582,9 @@ export class GraphRenderer {
               d3.selectAll('.graph-node')
                 .filter((n: GraphNode) => n.id === node.id)
                 .select('path')
-                .attr('stroke', '#fff')
-                .attr('stroke-width', styling.nodeBorderWidth);
+                .attr('stroke', this.nodeBorderColor(node))
+                .attr('stroke-width', styling.nodeBorderWidth)
+                .attr('stroke-dasharray', this.nodeBorderDash(node));
             });
             selectedNodes.clear();
           }
@@ -820,8 +855,9 @@ export class GraphRenderer {
         // Update visual highlighting
         d3.selectAll('.graph-node')
           .select('path')
-          .attr('stroke', '#fff')
-          .attr('stroke-width', styling.nodeBorderWidth);
+          .attr('stroke', (d: GraphNode) => this.nodeBorderColor(d))
+          .attr('stroke-width', styling.nodeBorderWidth)
+          .attr('stroke-dasharray', (d: GraphNode) => this.nodeBorderDash(d));
 
         selectedNodesInBox.forEach((node) => {
           d3.selectAll('.graph-node')
@@ -905,9 +941,10 @@ export class GraphRenderer {
       },
       onNodeDeselect: () => {
         selectedNodes.clear();
-        d3.selectAll('.graph-node')
-          .attr('stroke', '#fff')
-          .attr('stroke-width', styling.nodeBorderWidth);
+        d3.selectAll('.graph-node').select('path')
+          .attr('stroke', (d: GraphNode) => this.nodeBorderColor(d))
+          .attr('stroke-width', styling.nodeBorderWidth)
+          .attr('stroke-dasharray', (d: GraphNode) => this.nodeBorderDash(d));
       },
     };
 
@@ -1186,8 +1223,9 @@ export class GraphRenderer {
 
         // Update visual selection
         d3.selectAll('.graph-node').select('path')
-          .attr('stroke', '#fff')
-          .attr('stroke-width', styling.nodeBorderWidth);
+          .attr('stroke', (d: GraphNode) => this.nodeBorderColor(d))
+          .attr('stroke-width', styling.nodeBorderWidth)
+          .attr('stroke-dasharray', (d: GraphNode) => this.nodeBorderDash(d));
 
         neighbors.forEach(n => {
           d3.selectAll('.graph-node')


### PR DESCRIPTION
## Summary
- pip's libclang wheel ships no system/libc headers, so directory-walk C parsing (no `compile_commands.json`) hit constant missing-header/unknown-type cascades. Adds a bundled stub POSIX header set (`codecarto/data/c_stubs/`) plus platform defines so `#ifdef`-gated declarations take a real branch.
- Skips known single-platform compat files (apple/darwin/solaris/mingw/msvc/etc.) that no single build would ever compile together, reporting them in `meta.skipped_files`.
- `parse_files`/`parse_compile_commands` now classify and surface parser diagnostics (`missing_header`/`unknown_type`/`other` counts, worst-offending files) in `meta.diagnostics`.
- `graph_renderer.ts` renders a dashed amber border on nodes whose source file produced parser errors (`has_parse_warning`), and adds edge-kind-specific colors/widths/dashes for `CALLS`/`FIELD_OF`/`POINTS_TO`/`ALIASES`.
- Documents current `meta` response shape in `docs/api.md` and the proposed compile_commands-first follow-up in `docs/llm/next_steps/c_parser_phase3_compile_commands.md`.

## Test plan
- [x] `uv run pytest tests/` — 118 passed
- [x] `vite build` in `web/` — builds cleanly
- [ ] Manually parse a real multi-file C repo (e.g. git) via `/c-parser/github` and confirm `meta.diagnostics`/`meta.skipped_files` look sane and the warning border renders in the graph view