### PR TITLE
Complete the scope-drift survey: verify PR #70's followups + ship 1.4, 2.2

### DIFF
--- a/codecarto/models/source_data.py
+++ b/codecarto/models/source_data.py
@@ -1,5 +1,5 @@
 from pydantic import BaseModel
-from typing import List
+from typing import Iterator, List, Tuple
 
 
 class File(BaseModel):
@@ -18,6 +18,22 @@ class Folder(BaseModel):
     size: int = 0
     files: List[File] = []
     folders: List["Folder"] = []
+
+    def iter_files(self) -> Iterator[Tuple["Folder", File]]:
+        """Yield every (containing_folder, file) pair in this tree, recursively.
+
+        Shared traversal for callers that just need "every file under this
+        folder" (e.g. collecting parseable files by extension, fetching raw
+        content) instead of each hand-rolling its own recursive walk —
+        see docs/llm/next_steps/parser_consolidation_and_scope_drift.md's
+        finding 1.4. Not used by graph-building walks (e.g.
+        UnifiedParserService._walk_folder) that need per-level parent-id/
+        depth context beyond just the immediate containing folder.
+        """
+        for file in self.files:
+            yield self, file
+        for sub in self.folders:
+            yield from sub.iter_files()
 
 
 class RepoInfo(BaseModel):

--- a/codecarto/routers/c_parser_router.py
+++ b/codecarto/routers/c_parser_router.py
@@ -2,7 +2,6 @@ import asyncio
 import json
 import math
 import re
-import threading
 import time
 from pathlib import Path
 from typing import Optional
@@ -12,6 +11,7 @@ from fastapi.responses import HTMLResponse, StreamingResponse
 from pydantic import BaseModel
 
 from codecarto.util.exceptions import CodeCartoException, proc_exception
+from codecarto.util.threaded_feeder import start_threaded_feeder
 from codecarto.util.utilities import generate_return
 
 CParserRouter = APIRouter()
@@ -172,35 +172,37 @@ async def stream_c_github(request: CStreamGithubRequest) -> StreamingResponse:
     """Stream a GitHub C/H repo parse as Server-Sent Events.
 
     libclang parsing is synchronous, CPU-bound work, so it runs in a
-    background thread (same pattern as pam_router.py's log tailer) while
-    this coroutine drains an asyncio.Queue the thread feeds via
-    asyncio.run_coroutine_threadsafe. Nodes stream in real time, file by
-    file, as CParser.parse_files() works through pass 1. Edges need the
-    complete cross-file node set to resolve CALLS/FIELD_OF targets, so
-    they're only available — and only streamed — after the thread finishes.
+    background thread (see util/threaded_feeder.py — same pattern as
+    pam_router.py's log tailer) while this coroutine drains an asyncio.Queue
+    the thread feeds via asyncio.run_coroutine_threadsafe. Nodes stream in
+    real time, file by file, as CParser.parse_files() works through pass 1.
+    Edges need the complete cross-file node set to resolve CALLS/FIELD_OF
+    targets, so they're only available — and only streamed — after the
+    thread finishes.
     """
     from codecarto.services.c_parser_service import CParserService
 
-    loop = asyncio.get_running_loop()
-    queue: asyncio.Queue = asyncio.Queue()
     result_box: dict = {}
     error_box: dict = {}
     started_at = time.monotonic()
 
-    def on_progress(event_type: str, payload: dict) -> None:
-        asyncio.run_coroutine_threadsafe(queue.put((event_type, payload)), loop)
+    def make_worker(queue: asyncio.Queue, loop: asyncio.AbstractEventLoop):
+        def on_progress(event_type: str, payload: dict) -> None:
+            asyncio.run_coroutine_threadsafe(queue.put((event_type, payload)), loop)
 
-    def worker() -> None:
-        try:
-            result_box["value"] = CParserService.parse_github(
-                request.url, max_files=request.max_files, on_progress=on_progress
-            )
-        except Exception as exc:
-            error_box["exc"] = exc
-        finally:
-            asyncio.run_coroutine_threadsafe(queue.put(("__done__", None)), loop)
+        def worker() -> None:
+            try:
+                result_box["value"] = CParserService.parse_github(
+                    request.url, max_files=request.max_files, on_progress=on_progress
+                )
+            except Exception as exc:
+                error_box["exc"] = exc
+            finally:
+                asyncio.run_coroutine_threadsafe(queue.put(("__done__", None)), loop)
 
-    threading.Thread(target=worker, daemon=True).start()
+        return worker
+
+    queue = start_threaded_feeder(make_worker)
 
     async def generate():
         cols = 1

--- a/codecarto/routers/pam_router.py
+++ b/codecarto/routers/pam_router.py
@@ -30,7 +30,6 @@ import json
 import os
 import platform
 import subprocess
-import threading
 import time
 from pathlib import Path
 from typing import Dict, List, Optional, Set
@@ -39,6 +38,7 @@ from fastapi import APIRouter, Request, WebSocket, WebSocketDisconnect, Query
 from fastapi.responses import HTMLResponse, JSONResponse
 
 from codecarto.services.parsers.pam_parser import parse_line, read_history, tail_file
+from codecarto.util.threaded_feeder import start_threaded_feeder
 
 PamRouter = APIRouter()
 
@@ -112,27 +112,6 @@ def _journald_history(minutes: int = 30) -> List[str]:
         return []
 
 
-# ─── Background worker threads ────────────────────────────────────────────────
-
-def _tail_thread(log_path: str, queue: asyncio.Queue, loop: asyncio.AbstractEventLoop):
-    """Tail log file in a thread; push parsed events to async queue."""
-    try:
-        for line in tail_file(log_path, from_start=False):
-            ev = parse_line(line)
-            if ev:
-                asyncio.run_coroutine_threadsafe(queue.put(ev.to_dict()), loop)
-    except Exception as exc:
-        asyncio.run_coroutine_threadsafe(queue.put({'__error__': str(exc)}), loop)
-
-
-def _journald_thread(queue: asyncio.Queue, loop: asyncio.AbstractEventLoop):
-    """Stream journald in a thread; push parsed events to async queue."""
-    for line in _journald_tail():
-        ev = parse_line(line)
-        if ev:
-            asyncio.run_coroutine_threadsafe(queue.put(ev.to_dict()), loop)
-
-
 # ─── Broadcast loop ───────────────────────────────────────────────────────────
 
 async def _broadcast_loop(queue: asyncio.Queue):
@@ -182,30 +161,45 @@ async def on_pam_startup():
     """Start log-tailer thread and broadcast loop. Call from app startup."""
     global _log_path, _log_available, _log_error, _event_queue, _broadcast_task
 
-    _event_queue = asyncio.Queue()
-    loop = asyncio.get_event_loop()
-
     if _USE_JOURNALD:
-        t = threading.Thread(
-            target=_journald_thread, args=(_event_queue, loop), daemon=True
-        )
-        t.start()
+        def make_journald_worker(queue: asyncio.Queue, loop: asyncio.AbstractEventLoop):
+            def worker() -> None:
+                for line in _journald_tail():
+                    ev = parse_line(line)
+                    if ev:
+                        asyncio.run_coroutine_threadsafe(queue.put(ev.to_dict()), loop)
+            return worker
+
+        _event_queue = start_threaded_feeder(make_journald_worker)
         _log_available = True
         _log_path = "journald"
     else:
         _log_path = _detect_log_file()
         if _log_path:
             _log_available = True
-            t = threading.Thread(
-                target=_tail_thread, args=(_log_path, _event_queue, loop), daemon=True
-            )
-            t.start()
+            log_path = _log_path  # bind for the closure below
+
+            def make_tail_worker(queue: asyncio.Queue, loop: asyncio.AbstractEventLoop):
+                def worker() -> None:
+                    try:
+                        for line in tail_file(log_path, from_start=False):
+                            ev = parse_line(line)
+                            if ev:
+                                asyncio.run_coroutine_threadsafe(queue.put(ev.to_dict()), loop)
+                    except Exception as exc:
+                        asyncio.run_coroutine_threadsafe(queue.put({'__error__': str(exc)}), loop)
+                return worker
+
+            _event_queue = start_threaded_feeder(make_tail_worker)
         else:
             _log_available = False
             _log_error = (
                 "No readable auth log found. "
                 "Set PAM_LOG_FILE env var or PAM_USE_JOURNALD=1."
             )
+            # No thread to feed it, but _broadcast_loop still needs a queue
+            # to await on (harmlessly, forever) below.
+            _event_queue = asyncio.Queue()
 
     _broadcast_task = asyncio.create_task(_broadcast_loop(_event_queue))
 

--- a/codecarto/routers/unified_parser_router.py
+++ b/codecarto/routers/unified_parser_router.py
@@ -11,6 +11,8 @@ GET  /parse/cache         — list cached graphs
 DELETE /parse/cache/{key} — evict a cached graph
 """
 
+import json
+import asyncio
 from typing import Optional
 
 from fastapi import APIRouter, Query
@@ -22,6 +24,46 @@ from codecarto.util.exceptions import CodeCartoException, proc_exception
 from codecarto.util.utilities import generate_return
 
 UnifiedParserRouter = APIRouter()
+
+
+async def _stream_cached_graph(cached: dict, layout: str):
+    """Replay a cached graph as SSE events: meta → nodes (depth-sorted) → edges → done.
+
+    Shared between ``stream_parse`` and ``stream_from_url`` so the two
+    endpoints stay byte-for-byte identical on the cache-replay path —
+    prevents the kind of silent drift that would happen on the next edit if
+    each endpoint had its own copy.  Mirrors the frontend's ``_consumeSSE()``
+    in ``plot_service.ts``, which already serves as the single shared parser
+    for all three streaming callers.
+    """
+    nodes_raw = cached.get("graph", {}).get("nodes", {})
+    edges = cached.get("graph", {}).get("edges", [])
+    nodes_list: list[dict] = []
+    if isinstance(nodes_raw, dict):
+        for nid, nd in nodes_raw.items():
+            if not isinstance(nd, dict):
+                continue
+            flat: dict = {"id": nid}
+            for k, v in nd.items():
+                if k != "metadata":
+                    flat[k] = v
+            flat.update(nd.get("metadata", {}))
+            nodes_list.append(flat)
+    meta = {
+        "nodeCount": len(nodes_list),
+        "edgeCount": len(edges),
+        "layout": layout,
+        "from_cache": True,
+    }
+    yield f"event: meta\ndata: {json.dumps(meta)}\n\n"
+    await asyncio.sleep(0)
+    for node in sorted(nodes_list, key=lambda n: (n.get("depth", 9), n.get("id", ""))):
+        yield f"event: node\ndata: {json.dumps(node)}\n\n"
+        await asyncio.sleep(0)
+    for edge in edges:
+        yield f"event: edge\ndata: {json.dumps(edge)}\n\n"
+        await asyncio.sleep(0)
+    yield f"event: done\ndata: {json.dumps({'elapsed_ms': 0, 'from_cache': True})}\n\n"
 
 
 # ── Request bodies ─────────────────────────────────────────────────────────────
@@ -170,36 +212,8 @@ async def stream_parse(request: UnifiedParseRequest):
         )
         cached = CacheService.get(key)
         if cached is not None:
-            import json, asyncio
-
-            async def stream_cached():
-                nodes_raw = cached.get("graph", {}).get("nodes", {})
-                edges = cached.get("graph", {}).get("edges", [])
-                nodes_list = []
-                if isinstance(nodes_raw, dict):
-                    for nid, nd in nodes_raw.items():
-                        if not isinstance(nd, dict):
-                            continue
-                        meta_attrs = nd.get("metadata", {})
-                        flat: dict = {"id": nid}
-                        for k, v in nd.items():
-                            if k != "metadata":
-                                flat[k] = v
-                        flat.update(meta_attrs)
-                        nodes_list.append(flat)
-                meta = {"nodeCount": len(nodes_list), "edgeCount": len(edges), "layout": request.layout, "from_cache": True}
-                yield f"event: meta\ndata: {json.dumps(meta)}\n\n"
-                await asyncio.sleep(0)
-                for node in sorted(nodes_list, key=lambda n: (n.get("depth", 9), n.get("id", ""))):
-                    yield f"event: node\ndata: {json.dumps(node)}\n\n"
-                    await asyncio.sleep(0)
-                for edge in edges:
-                    yield f"event: edge\ndata: {json.dumps(edge)}\n\n"
-                    await asyncio.sleep(0)
-                yield f"event: done\ndata: {json.dumps({'elapsed_ms': 0, 'from_cache': True})}\n\n"
-
             return StreamingResponse(
-                stream_cached(),
+                _stream_cached_graph(cached, request.layout),
                 media_type="text/event-stream",
                 headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
             )
@@ -214,7 +228,6 @@ async def stream_parse(request: UnifiedParseRequest):
             ):
                 yield chunk
         except Exception as exc:
-            import json
             yield f"event: error\ndata: {json.dumps({'message': str(exc)})}\n\n"
 
     return StreamingResponse(
@@ -252,41 +265,13 @@ async def stream_from_url(request: StreamUrlRequest):
     )
     cached = CacheService.get(key)
     if cached is not None:
-        import json, asyncio
-
-        async def stream_cached_url():
-            nodes_raw = cached.get("graph", {}).get("nodes", {})
-            edges = cached.get("graph", {}).get("edges", [])
-            nodes_list = []
-            if isinstance(nodes_raw, dict):
-                for nid, nd in nodes_raw.items():
-                    if not isinstance(nd, dict):
-                        continue
-                    meta_attrs = nd.get("metadata", {})
-                    flat: dict = {"id": nid}
-                    for k, v in nd.items():
-                        if k != "metadata":
-                            flat[k] = v
-                    flat.update(meta_attrs)
-                    nodes_list.append(flat)
-            meta = {"nodeCount": len(nodes_list), "edgeCount": len(edges), "layout": request.layout, "from_cache": True}
-            yield f"event: meta\ndata: {json.dumps(meta)}\n\n"
-            await asyncio.sleep(0)
-            for node in sorted(nodes_list, key=lambda n: (n.get("depth", 9), n.get("id", ""))):
-                yield f"event: node\ndata: {json.dumps(node)}\n\n"
-                await asyncio.sleep(0)
-            for edge in edges:
-                yield f"event: edge\ndata: {json.dumps(edge)}\n\n"
-                await asyncio.sleep(0)
-            yield f"event: done\ndata: {json.dumps({'elapsed_ms': 0, 'from_cache': True})}\n\n"
-
         return StreamingResponse(
-            stream_cached_url(),
+            _stream_cached_graph(cached, request.layout),
             media_type="text/event-stream",
             headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
         )
 
-    # GitHub path 
+    # GitHub path
     if is_github_url(request.url):
         async def generate():
             try:

--- a/codecarto/services/github_service.py
+++ b/codecarto/services/github_service.py
@@ -64,16 +64,10 @@ async def _fetch_content_for_folder(folder: Folder, concurrency: int = 8) -> Non
     from codecarto.services.parsers.language_parser import ParserRegistry
     registered_exts = set(ParserRegistry.all_extensions())
 
-    targets: list[File] = []
-
-    def collect(f: Folder) -> None:
-        for file in f.files:
-            if file.url and Path(file.name).suffix.lower() in registered_exts:
-                targets.append(file)
-        for sub in f.folders:
-            collect(sub)
-
-    collect(folder)
+    targets: list[File] = [
+        file for _, file in folder.iter_files()
+        if file.url and Path(file.name).suffix.lower() in registered_exts
+    ]
 
     semaphore = asyncio.Semaphore(concurrency)
 

--- a/codecarto/services/parsers/c_language_parser.py
+++ b/codecarto/services/parsers/c_language_parser.py
@@ -139,6 +139,7 @@ class CLangaugeParser:
             return nx.DiGraph()
 
         paths: list[Path] = []
+        real_paths: list[Path] = []   # real on-disk paths only (not virtual)
         contents: dict[str, str] = {}
 
         for f in files:
@@ -152,6 +153,7 @@ class CLangaugeParser:
             real_path = Path(f.url) if f.url else None
             if real_path is not None and real_path.exists():
                 paths.append(real_path)
+                real_paths.append(real_path)
             elif f.raw:
                 virtual_path = self._VIRTUAL_ROOT / f.name
                 paths.append(virtual_path)
@@ -160,9 +162,21 @@ class CLangaugeParser:
         if not paths:
             return nx.DiGraph()
 
+        # For local files, derive the project root so libclang gets `-I<root>`
+        # and resolves multi-directory `#include "foo.h"` correctly — the same
+        # way the dedicated /c-parser/directory endpoint does via
+        # CParserService.parse_directory(extra_args=default_parse_args(project_root=...)).
+        # For GitHub/virtual content there is no real project root, so the
+        # no-arg call (no -I flag) is still correct for that branch.
+        project_root: Path | None = None
+        if real_paths:
+            import os
+            common = Path(os.path.commonpath([str(p) for p in real_paths]))
+            project_root = common if common.is_dir() else common.parent
+
         raw: dict = CParser().parse_files(
             paths,
-            extra_args=default_parse_args(),
+            extra_args=default_parse_args(project_root=project_root),
             contents=contents or None,
         )
         return self._convert(raw, depth)

--- a/codecarto/services/unified_parser_service.py
+++ b/codecarto/services/unified_parser_service.py
@@ -290,7 +290,7 @@ class UnifiedParserService:
 
         # ── Phase 2: fetch content + parse symbols concurrently ───────────────
         parseable: list[tuple[str, str, str]] = []
-        _collect_parseable(structure_root, structure_root.name, allowed_exts, parseable)
+        _collect_parseable(structure_root, allowed_exts, parseable)
 
         if not parseable:
             elapsed = int((time.monotonic() - start) * 1000)
@@ -705,17 +705,14 @@ def _split_by_batch_mode(
 
 def _collect_parseable(
     folder: Folder,
-    folder_name: str,
     allowed_exts: set[str],
     result: list[tuple[str, str, str]],
 ) -> None:
-    """Recursively collect (folder_name, file_name, download_url) for parseable files."""
-    for f in folder.files:
+    """Collect (folder_name, file_name, download_url) for parseable files."""
+    for owning_folder, f in folder.iter_files():
         ext = Path(f.name).suffix.lower()
         if ext in allowed_exts and f.url:
-            result.append((folder_name, f.name, f.url))
-    for sub in folder.folders:
-        _collect_parseable(sub, sub.name, allowed_exts, result)
+            result.append((owning_folder.name, f.name, f.url))
 
 
 def _ext_to_language(ext: str) -> str:
@@ -807,18 +804,12 @@ def _add_python_dependency_edges(
         return
 
     raw_by_file_id: dict[str, str] = {}
-
-    def collect(folder: Folder) -> None:
-        for file in folder.files:
-            if Path(file.name).suffix.lower() != ".py" or not file.raw:
-                continue
-            file_id = file_id_by_stem.get(Path(file.name).stem)
-            if file_id:
-                raw_by_file_id[file_id] = file.raw
-        for sub in folder.folders:
-            collect(sub)
-
-    collect(root)
+    for _, file in root.iter_files():
+        if Path(file.name).suffix.lower() != ".py" or not file.raw:
+            continue
+        file_id = file_id_by_stem.get(Path(file.name).stem)
+        if file_id:
+            raw_by_file_id[file_id] = file.raw
 
     internal_edges, external_refs = _resolve_python_dependencies(file_id_by_stem, raw_by_file_id)
 

--- a/codecarto/services/unified_parser_service.py
+++ b/codecarto/services/unified_parser_service.py
@@ -22,7 +22,7 @@ import json
 import math
 import os
 from pathlib import Path
-from typing import AsyncIterator, Optional
+from typing import AsyncIterator, Callable, Iterable, Optional, TypeVar
 
 import networkx as nx
 
@@ -417,24 +417,14 @@ class UnifiedParserService:
 
         # Split into per-file (progressive) vs batch_whole_tree (correctness
         # over progressiveness — e.g. C, for cross-file CALLS resolution).
-        per_file: list[tuple[str, str, str, object]] = []
-        batched: dict[int, tuple[object, list[tuple[str, str, str]]]] = {}
-        for folder_name, file_name, dl_url in parseable:
-            ext = Path(file_name).suffix.lower()
-            parser = ParserRegistry.get(ext)
-            if parser is None:
-                continue
-            if getattr(parser, "batch_whole_tree", False):
-                key = id(parser)
-                if key not in batched:
-                    batched[key] = (parser, [])
-                batched[key][1].append((folder_name, file_name, dl_url))
-            else:
-                per_file.append((folder_name, file_name, dl_url, parser))
+        per_file, batched = _split_by_batch_mode(
+            parseable,
+            ext_of=lambda item: Path(item[1]).suffix.lower(),
+        )
 
         tasks = [
-            asyncio.create_task(fetch_and_parse_file(fn, fname, du, parser))
-            for fn, fname, du, parser in per_file
+            asyncio.create_task(fetch_and_parse_file(*item, parser))
+            for item, parser in per_file
         ] + [
             asyncio.create_task(fetch_and_parse_batch(parser, entries))
             for parser, entries in batched.values()
@@ -624,9 +614,10 @@ class UnifiedParserService:
                 continue
             files_by_ext.setdefault(ext, []).append(file)
 
+        # First pass: add all file nodes to the graph.
+        # Collect items that need depth-2 parsing for a separate dispatch step.
+        parseable_files: list[tuple[File, str]] = []
         for ext, file_list in files_by_ext.items():
-            parser = ParserRegistry.get(ext) if depth >= 2 else None
-
             for file in file_list:
                 file_id = f"file::{folder.name}/{file.name}"
 
@@ -644,19 +635,25 @@ class UnifiedParserService:
                 )
                 graph.add_edge(folder_id, file_id, **make_edge("contains"))
 
-                # Dispatch to language parser for depth-2+ nodes
-                if parser is not None and depth >= 2 and file.raw:
-                    if getattr(parser, "batch_whole_tree", False):
-                        key = id(parser)
-                        if key not in pending:
-                            pending[key] = (parser, [])
-                        pending[key][1].append((file, file_id))
-                    else:
-                        try:
-                            sub = parser.parse_files([file], depth=depth)
-                            _merge_subgraph(graph, sub, file_id)
-                        except Exception:
-                            pass  # Best-effort; directory structure still present
+                if depth >= 2 and file.raw:
+                    parseable_files.append((file, file_id))
+
+        # Second pass: split by batch mode and dispatch.
+        if parseable_files:
+            per_item, batch_items = _split_by_batch_mode(
+                parseable_files,
+                ext_of=lambda item: Path(item[0].name).suffix.lower(),
+            )
+            for (file, file_id), parser in per_item:
+                try:
+                    sub = parser.parse_files([file], depth=depth)
+                    _merge_subgraph(graph, sub, file_id)
+                except Exception:
+                    pass  # Best-effort; directory structure still present
+            for key, (parser, items) in batch_items.items():
+                if key not in pending:
+                    pending[key] = (parser, [])
+                pending[key][1].extend(items)
 
         # ── Subfolders ────────────────────────────────────────────────────────
         for subfolder in folder.folders:
@@ -668,6 +665,43 @@ class UnifiedParserService:
 
 
 # ── Helpers ───────────────────────────────────────────────────────────────────
+
+_T = TypeVar("_T")
+
+
+def _split_by_batch_mode(
+    items: Iterable[_T],
+    ext_of: Callable[[_T], str],
+) -> tuple[list[tuple[_T, object]], dict[int, tuple[object, list[_T]]]]:
+    """Group items by whether their registered parser uses ``batch_whole_tree``.
+
+    Returns
+    -------
+    per_item : list of (item, parser)
+        Items whose parser should be dispatched file-by-file (progressive).
+    batched : dict mapping id(parser) → (parser, [items])
+        Items whose parser requires the full set at once (e.g. C, for
+        cross-file CALLS/type resolution — see CLangaugeParser.batch_whole_tree).
+
+    The two call sites' downstream handling is intentionally kept separate:
+    the GitHub-streaming path emits SSE events via ``node_events_for``; the
+    local-directory path merges into an ``nx.DiGraph`` via ``_merge_subgraph``
+    / ``_parse_pending_batches``.  Only the *grouping step* is shared here.
+    """
+    per_item: list[tuple[_T, object]] = []
+    batched: dict[int, tuple[object, list[_T]]] = {}
+    for item in items:
+        parser = ParserRegistry.get(ext_of(item))
+        if parser is None:
+            continue
+        if getattr(parser, "batch_whole_tree", False):
+            key = id(parser)
+            if key not in batched:
+                batched[key] = (parser, [])
+            batched[key][1].append(item)
+        else:
+            per_item.append((item, parser))
+    return per_item, batched
 
 def _collect_parseable(
     folder: Folder,

--- a/codecarto/util/threaded_feeder.py
+++ b/codecarto/util/threaded_feeder.py
@@ -1,0 +1,44 @@
+"""
+Threaded Feeder
+================
+Shared setup for the "background thread feeds an asyncio.Queue" pattern
+used by SSE/WebSocket endpoints that wrap blocking or CPU-bound work
+(libclang parsing, tailing a log file) without freezing the event loop.
+
+Before this, c_parser_router.py's /stream-github and pam_router.py's log
+tailer each hand-rolled the same thread-spawn + queue-feed wiring
+independently — see docs/llm/next_steps/parser_consolidation_and_scope_drift.md,
+finding 2.2. c_parser_router.py's own comment even named the duplication
+("same pattern as pam_router.py's log tailer") without it ever being lifted.
+"""
+
+import asyncio
+import threading
+from typing import Callable
+
+
+def start_threaded_feeder(
+    worker_factory: Callable[[asyncio.Queue, asyncio.AbstractEventLoop], Callable[[], None]],
+) -> asyncio.Queue:
+    """Create an ``asyncio.Queue``, capture the running event loop, and
+    start a daemon thread running the worker *worker_factory* builds.
+
+    *worker_factory* receives the queue and loop and must return a
+    zero-arg callable — the actual thread target — so it can close over
+    them to call ``asyncio.run_coroutine_threadsafe(queue.put(...), loop)``
+    from inside the thread. The two real call sites' worker shapes differ
+    enough (one is a zero-arg closure with no other args; one tails a log
+    file and takes a path) that only this setup step is unified, not the
+    full worker body.
+
+    This centralizes the part most likely to have a subtle bug: forgetting
+    ``daemon=True`` (which would keep the process alive on shutdown), or
+    capturing the loop from inside the thread instead of before starting
+    it — ``asyncio.get_running_loop()`` only works from the event-loop
+    thread; a plain OS thread has no running loop of its own and would
+    raise ``RuntimeError``.
+    """
+    loop = asyncio.get_running_loop()
+    queue: asyncio.Queue = asyncio.Queue()
+    threading.Thread(target=worker_factory(queue, loop), daemon=True).start()
+    return queue

--- a/docs/llm/next_steps/parser_consolidation_and_scope_drift.md
+++ b/docs/llm/next_steps/parser_consolidation_and_scope_drift.md
@@ -9,12 +9,13 @@ Each finding has file:line references, a concrete reproduction of the
 duplication/drift, and a suggested direction. Ranked roughly by impact
 within each category.
 
-**Status (2026-06-28, later same day): 1.1 implemented**, including a
-same-day follow-up extending dependency-edge resolution to the
-GitHub-streaming path (see its own section below for what actually shipped
-— the real picture turned out different from the initial survey finding).
-Everything else in this document is still just documentation — 1.2–1.4 and
-all of section 2 are not yet implemented.
+**Status (2026-06-29): everything in this document is now implemented.**
+1.1 shipped 2026-06-28 (see its own section — the real picture turned out
+different from the initial survey finding). 1.2/1.3/2.1/2.3 were
+implemented by PR #70 (`copilot-swe-agent`) on `caching-and-parser-consolidation`
+and verified+cherry-picked here (see each section for what was checked and
+what tests were added — the original PR shipped zero tests). 1.4 and 2.2
+were implemented in this same pass. Branch: `followup-lifts-completion`.
 
 ---
 
@@ -115,9 +116,18 @@ two different packages' `__init__.py`) can't be disambiguated; the
 last-visited one wins. Pre-existing characteristic of this id scheme, not
 newly introduced, and not addressed by this update.
 
-### 1.2 `batch_whole_tree` dispatch-splitting logic is duplicated, not shared
+### 1.2 `batch_whole_tree` dispatch-splitting logic is duplicated, not shared [DONE 2026-06-29]
 
 **Impact: medium — same ~15-line algorithm reimplemented twice with different data shapes.**
+
+**Shipped via PR #70, exactly as suggested below**: `_split_by_batch_mode(items, ext_of)`
+in `unified_parser_service.py`, used by both `stream_parse_url` and
+`_walk_folder` (the latter restructured into two passes: collect file
+nodes, then split-and-dispatch). PR #70 added no tests; added 5 direct
+unit tests (`TestSplitByBatchMode` in `test_unified_parser_service.py`) —
+pure function, no I/O, exactly as easy to test in isolation as hoped.
+Confirmed no regression: all pre-existing `TestCBatchWholeTree` end-to-end
+tests still pass unchanged.
 
 Both code paths in `unified_parser_service.py` need to split a list of
 files into "dispatch one-at-a-time" vs "dispatch as one batch per parser"
@@ -163,9 +173,22 @@ to extract the extension from an item. Low risk — it's pure grouping logic
 with no I/O, easy to unit test in isolation from the two call sites' very
 different downstream handling.
 
-### 1.3 Functional parity gap between the two C parsing entry points (`-I<project root>`)
+### 1.3 Functional parity gap between the two C parsing entry points (`-I<project root>`) [DONE 2026-06-29]
 
 **Impact: medium — silently wrong output for multi-directory C projects parsed via the generic path, not just a style issue.**
+
+**Shipped via PR #70**: `c_language_parser.py`'s `parse_files` now tracks
+real on-disk paths separately, computes `os.path.commonpath` over them,
+and passes the result (or its parent, if commonpath itself resolves to a
+single file rather than a directory) as `project_root` to
+`default_parse_args`. PR #70 added no tests; live-verified by hand before
+trusting it — built a real multi-directory project (`foo.h` at the root,
+`foo.c`/`main.c` in `src/`, `#include "foo.h"` only resolvable via
+`-I<root>`), confirmed the OLD code fails (`libclang: 'foo.h' file not
+found`, zero `calls` edges) and the NEW code resolves it correctly
+(`main -> foo_fn` edge present). Added 3 regression tests
+(`TestCLanguageParserProjectRoot` in `test_c_parser_service.py`), including
+the single-file commonpath-returns-a-file-not-a-dir edge case.
 
 There are two independent entry points into `CParser`, and they don't pass
 the same compiler args:
@@ -203,29 +226,37 @@ at line 152-154) — their common ancestor directory could be computed and
 passed through as `project_root`. For GitHub/virtual files there's no real
 project root, so the current no-arg call stays correct for that branch.
 
-### 1.4 (Minor) Recursive Folder-tree walking reimplemented at ~4 call sites
+### 1.4 (Minor) Recursive Folder-tree walking reimplemented at ~4 call sites [DONE 2026-06-29]
 
 **Impact: low — small, but a `Folder.walk_files()` method would remove repetition.**
 
-`Folder` (`models/source_data.py`) has no traversal helper, so each
-consumer hand-rolls its own recursive walk:
-`_collect_parseable` (`unified_parser_service.py:605`), the `pending`-dict
-walk inside `_walk_folder` (`unified_parser_service.py:522`),
-`_fetch_content_for_folder`'s `collect()` (`github_service.py:69`, added
-this session), and `parser_service.py`'s `read_directory_recursive`
-(filesystem-specific, not `Folder`-based, so not directly affected). A
-`Folder.iter_files() -> Iterator[tuple[Folder, File]]` generator method
-would let three of these collapse to a one-line `for` loop. Not urgent —
-flagging since it'll keep recurring as more call sites need "every file in
-this tree" until someone adds it.
+Added `Folder.iter_files() -> Iterator[tuple[Folder, File]]`
+(`models/source_data.py`) and collapsed the 3 genuine matches:
+`_collect_parseable` and `_add_python_dependency_edges`
+(`unified_parser_service.py`), `_fetch_content_for_folder`'s `collect()`
+(`github_service.py`). `parser_service.py`'s `read_directory_recursive`
+no longer exists (deleted in 1.1). Deliberately did **not** touch
+`_walk_folder`'s own recursion — on closer look it builds graph nodes/
+edges with per-level parent-id/depth context as it descends, which isn't
+actually a "give me a flat list of files" pattern; forcing it through this
+iterator would be a worse fit, not a cleaner one. 5 new tests
+(`test_source_data.py`).
 
 ---
 
 ## 2. Other scope drift
 
-### 2.1 SSE cache-replay block duplicated verbatim across two router endpoints
+### 2.1 SSE cache-replay block duplicated verbatim across two router endpoints [DONE 2026-06-29]
 
 **Impact: medium — ~25 identical lines, the kind of duplication that silently diverges on the next edit.**
+
+**Shipped via PR #70, exactly as suggested below**: `_stream_cached_graph(cached, layout)`
+in `unified_parser_router.py`, called from both `stream_parse` and
+`stream_from_url`. PR #70 added no tests; added `test_unified_parser_router.py`
+covering the generator directly (event order, depth-sort, `from_cache`
+marking, malformed-entry handling) plus an end-to-end test that actually
+proves the point of the extraction — `/parse/stream` and `/parse/stream-url`
+produce **byte-for-byte identical** SSE output for the same cached entry.
 
 `unified_parser_router.py` has two nearly byte-for-byte identical inner
 functions for replaying a cached graph as SSE:
@@ -249,9 +280,24 @@ equivalent for the cache-replay side.
 (module-level in `unified_parser_router.py`, or a method on
 `UnifiedParserService`) and call it from both endpoints.
 
-### 2.2 Thread → `asyncio.Queue` → SSE bridge hand-rolled independently twice
+### 2.2 Thread → `asyncio.Queue` → SSE bridge hand-rolled independently twice [DONE 2026-06-29]
 
 **Impact: low-medium — same wiring pattern, not literally copy-pasted, so a shared helper needs to fit both shapes.**
+
+**Shipped**: new `codecarto/util/threaded_feeder.py` —
+`start_threaded_feeder(worker_factory)` creates the queue, captures the
+running loop, and starts the daemon thread; `worker_factory(queue, loop)`
+returns the zero-arg thread target, accommodating both call sites' very
+different worker shapes (one fully closure-based, one taking a log path)
+without forcing either into an awkward signature. `pam_router.py`'s
+`_tail_thread`/`_journald_thread` became inline closures built by a
+factory inside `on_pam_startup` rather than top-level functions taking
+explicit `(queue, loop)` args — preserves the "no log file found" fallback
+exactly (`_event_queue` still gets a real, just unfed, `Queue`). 5 new
+direct unit tests (`test_threaded_feeder.py`); live-verified
+`on_pam_startup()` against a real `PAM_LOG_FILE` and the "no log available"
+path; existing `/c-parser/stream-github` test coverage
+(`test_c_parser_router.py`) passes unchanged.
 
 `c_parser_router.py`'s `/stream-github`
 ([c_parser_router.py:170-203](../../../codecarto/routers/c_parser_router.py#L170-L203))
@@ -278,9 +324,14 @@ daemon thread, returning the queue for the caller to drain however it
 needs. Lower priority than 2.1 — the win is smaller and the two call sites'
 draining logic genuinely differs.
 
-### 2.3 Frontend: confirmed-still-present dead `actions.ts` methods
+### 2.3 Frontend: confirmed-still-present dead `actions.ts` methods [DONE 2026-06-29]
 
 **Impact: low — already identified in a previous session ([memory: Architectural Unification Pass](../ARCHITECTURE.md)), re-verified here, still not removed.**
+
+**Shipped via PR #70.** Re-verified via repo-wide grep after cherry-picking:
+zero remaining references to `UIActions`, `adaptCGraphToGJGF`, `plotCFile`,
+`plotCDirectory`, or `clearUploads` anywhere in `web/src`. Frontend build
+(`npm run build`) passes cleanly.
 
 Zero call sites anywhere in `web/src` (checked via grep for
 `actions.<ns>.<method>(` across all components) for:
@@ -301,15 +352,19 @@ only to keep one place that confirms it's still true as of 2026-06-28.
 
 ---
 
-## Suggested order of attack
+## Status: all items shipped
 
-1. ~~**1.1** (consolidate `ParserService` + build a real dependency view)~~
-   — **done 2026-06-28.**
-2. **1.3** (C project-root parity) — small diff, fixes a real correctness
-   gap rather than just tidying.
-3. **2.1** (SSE cache-replay extraction) — small diff, removes the
-   duplication most likely to silently diverge next time someone touches
-   either streaming endpoint.
-4. **1.2**, **2.2**, **1.4** — lower urgency, take when touching adjacent
-   code rather than as standalone work.
-5. **2.3** — trivial deletion, bundle with any of the above.
+1. ~~**1.1**~~ — done 2026-06-28 (`caching-and-parser-consolidation`).
+2. ~~**1.2, 1.3, 2.1, 2.3**~~ — implemented by PR #70
+   (`copilot/frontend-integration-golden-layout`, `copilot-swe-agent`),
+   verified and cherry-picked clean onto `followup-lifts-completion`
+   2026-06-29. PR #70 itself also carries an unrelated Golden Layout
+   frontend integration mixed into the same branch — only the
+   "followups" commit (`d0e685f`) was cherry-picked; the Golden Layout
+   work is a separate concern not covered by this survey.
+3. ~~**1.4, 2.2**~~ — implemented 2026-06-29, same branch.
+
+Every item shipped with tests added in this pass (PR #70's own commit had
+none) and either a live manual verification or a full-suite pass
+confirming no regression. Nothing outstanding from this survey as of
+2026-06-29.

--- a/tests/test_c_parser_service.py
+++ b/tests/test_c_parser_service.py
@@ -539,3 +539,77 @@ class TestCLanguageParserUnsavedFiles:
 
         names = {d["label"] for _, d in g.nodes(data=True)}
         assert "from_disk" in names
+
+
+@requires_libclang
+class TestCLanguageParserProjectRoot:
+    """CLangaugeParser.parse_files() derives a project root from real
+    on-disk file paths (os.path.commonpath) and passes it to libclang as
+    -I<root> — without this, a multi-directory C project's #include "foo.h"
+    expecting the build's root include (not just the including file's own
+    directory) silently fails to resolve, even for local repos where the
+    project root is fully knowable. Matches what the dedicated
+    /c-parser/directory endpoint already did via
+    CParserService.parse_directory(extra_args=default_parse_args(project_root=...))."""
+
+    def _write_project(self, tmp_path):
+        """foo.h at the project root, foo.c/main.c in a src/ subdirectory —
+        #include "foo.h" only resolves via -I<root>, not via the including
+        file's own directory (src/)."""
+        (tmp_path / "foo.h").write_text("int foo_fn(int x);\n")
+        src = tmp_path / "src"
+        src.mkdir()
+        (src / "foo.c").write_text(
+            '#include "foo.h"\nint foo_fn(int x) { return x * 2; }\n'
+        )
+        (src / "main.c").write_text(
+            '#include "foo.h"\nint main(void) { return foo_fn(5); }\n'
+        )
+        return tmp_path, src
+
+    def _files(self, root, src):
+        from codecarto.models.source_data import File
+        return [
+            File(url=str(root / "foo.h"), name="foo.h", size=0, raw=(root / "foo.h").read_text()),
+            File(url=str(src / "foo.c"), name="foo.c", size=0, raw=(src / "foo.c").read_text()),
+            File(url=str(src / "main.c"), name="main.c", size=0, raw=(src / "main.c").read_text()),
+        ]
+
+    def test_header_outside_including_files_own_directory_resolves(self, tmp_path):
+        from codecarto.services.parsers.c_language_parser import CLangaugeParser
+
+        root, src = self._write_project(tmp_path)
+        g = CLangaugeParser().parse_files(self._files(root, src), depth=2)
+
+        labels = {d.get("label") for _, d in g.nodes(data=True)}
+        assert "foo_fn" in labels and "main" in labels
+
+    def test_cross_file_call_resolves_through_root_include(self, tmp_path):
+        """The real payoff: without -I<root>, foo.h can't be found at all,
+        so foo_fn's declaration never reaches main.c and the cross-file
+        calls edge never resolves."""
+        from codecarto.services.parsers.c_language_parser import CLangaugeParser
+
+        root, src = self._write_project(tmp_path)
+        g = CLangaugeParser().parse_files(self._files(root, src), depth=2)
+
+        call_edges = [
+            (s, t) for s, t, d in g.edges(data=True) if d.get("kind") == "calls"
+        ]
+        assert any("main" in s and "foo_fn" in t for s, t in call_edges), (
+            f"expected main -> foo_fn calls edge, got: {call_edges}"
+        )
+
+    def test_single_file_project_root_falls_back_to_parent_dir(self, tmp_path):
+        """os.path.commonpath of a single path returns that file itself, not
+        a directory — must fall back to its parent, not pass a file as -I."""
+        from codecarto.services.parsers.c_language_parser import CLangaugeParser
+        from codecarto.models.source_data import File
+
+        (tmp_path / "solo.c").write_text("int solo_fn(void) { return 1; }\n")
+        f = File(url=str(tmp_path / "solo.c"), name="solo.c", size=0, raw="int solo_fn(void) { return 1; }\n")
+
+        g = CLangaugeParser().parse_files([f], depth=2)
+
+        labels = {d.get("label") for _, d in g.nodes(data=True)}
+        assert "solo_fn" in labels

--- a/tests/test_source_data.py
+++ b/tests/test_source_data.py
@@ -1,0 +1,62 @@
+"""
+Tests for codecarto.models.source_data.Folder.iter_files() — the shared
+recursive (folder, file) traversal extracted so callers needing "every
+file under this folder" don't each hand-roll their own recursive walk
+(see docs/llm/next_steps/parser_consolidation_and_scope_drift.md, 1.4).
+Used by _collect_parseable and _add_python_dependency_edges
+(unified_parser_service.py) and _fetch_content_for_folder
+(github_service.py).
+"""
+
+from codecarto.models.source_data import File, Folder
+
+
+class TestFolderIterFiles:
+    def test_empty_folder_yields_nothing(self):
+        f = Folder(name="root", size=0, files=[], folders=[])
+        assert list(f.iter_files()) == []
+
+    def test_flat_files_yield_self_as_owning_folder(self):
+        a = File(name="a.py")
+        b = File(name="b.py")
+        root = Folder(name="root", size=0, files=[a, b], folders=[])
+
+        results = list(root.iter_files())
+
+        assert results == [(root, a), (root, b)]
+
+    def test_nested_files_yield_their_own_subfolder(self):
+        nested = File(name="nested.py")
+        sub = Folder(name="pkg", size=0, files=[nested], folders=[])
+        top = File(name="top.py")
+        root = Folder(name="root", size=0, files=[top], folders=[sub])
+
+        results = list(root.iter_files())
+
+        assert (root, top) in results
+        assert (sub, nested) in results
+        assert len(results) == 2
+
+    def test_deeply_nested_folders_all_visited(self):
+        f3 = File(name="deep.py")
+        level3 = Folder(name="level3", size=0, files=[f3], folders=[])
+        level2 = Folder(name="level2", size=0, files=[], folders=[level3])
+        level1 = Folder(name="level1", size=0, files=[], folders=[level2])
+        root = Folder(name="root", size=0, files=[], folders=[level1])
+
+        results = list(root.iter_files())
+
+        assert results == [(level3, f3)]
+
+    def test_multiple_subfolders_all_visited(self):
+        fa = File(name="a.py")
+        fb = File(name="b.py")
+        sub_a = Folder(name="a", size=0, files=[fa], folders=[])
+        sub_b = Folder(name="b", size=0, files=[fb], folders=[])
+        root = Folder(name="root", size=0, files=[], folders=[sub_a, sub_b])
+
+        results = list(root.iter_files())
+
+        assert set(f.name for _, f in results) == {"a.py", "b.py"}
+        owning_names = {owner.name for owner, _ in results}
+        assert owning_names == {"a", "b"}

--- a/tests/test_threaded_feeder.py
+++ b/tests/test_threaded_feeder.py
@@ -1,0 +1,91 @@
+"""
+Tests for codecarto.util.threaded_feeder.start_threaded_feeder — the
+shared thread-spawn + queue-feed wiring extracted from
+c_parser_router.py's /stream-github and pam_router.py's log tailer (see
+docs/llm/next_steps/parser_consolidation_and_scope_drift.md, 2.2).
+"""
+
+import asyncio
+import threading
+
+import pytest
+
+from codecarto.util.threaded_feeder import start_threaded_feeder
+
+
+class TestStartThreadedFeeder:
+    @pytest.mark.asyncio
+    async def test_worker_runs_in_a_separate_thread(self):
+        seen_thread_id = {}
+
+        def make_worker(queue, loop):
+            def worker():
+                seen_thread_id["id"] = threading.get_ident()
+                asyncio.run_coroutine_threadsafe(queue.put("done"), loop)
+            return worker
+
+        queue = start_threaded_feeder(make_worker)
+        await queue.get()
+
+        assert seen_thread_id["id"] != threading.get_ident()
+
+    @pytest.mark.asyncio
+    async def test_thread_is_daemon(self):
+        def make_worker(queue, loop):
+            def worker():
+                asyncio.run_coroutine_threadsafe(
+                    queue.put(threading.current_thread().daemon), loop
+                )
+            return worker
+
+        queue = start_threaded_feeder(make_worker)
+        is_daemon = await queue.get()
+
+        assert is_daemon is True
+
+    @pytest.mark.asyncio
+    async def test_events_pushed_from_thread_are_received_in_order(self):
+        def make_worker(queue, loop):
+            def worker():
+                for i in range(5):
+                    asyncio.run_coroutine_threadsafe(queue.put(i), loop)
+            return worker
+
+        queue = start_threaded_feeder(make_worker)
+
+        received = [await queue.get() for _ in range(5)]
+        assert received == [0, 1, 2, 3, 4]
+
+    @pytest.mark.asyncio
+    async def test_worker_factory_receives_a_real_queue_and_loop(self):
+        captured = {}
+
+        def make_worker(queue, loop):
+            captured["queue"] = queue
+            captured["loop"] = loop
+            def worker():
+                pass
+            return worker
+
+        returned_queue = start_threaded_feeder(make_worker)
+
+        assert captured["queue"] is returned_queue
+        assert isinstance(captured["queue"], asyncio.Queue)
+        assert captured["loop"] is asyncio.get_running_loop()
+
+    @pytest.mark.asyncio
+    async def test_exception_in_worker_does_not_propagate_to_caller(self):
+        """A worker that raises must not crash the calling coroutine — it's
+        running in a separate OS thread, exceptions there are the worker's
+        own responsibility to report (e.g. via queue.put({'__error__': ...}))."""
+        def make_worker(queue, loop):
+            def worker():
+                try:
+                    raise RuntimeError("boom")
+                finally:
+                    asyncio.run_coroutine_threadsafe(queue.put("survived"), loop)
+            return worker
+
+        queue = start_threaded_feeder(make_worker)
+        result = await queue.get()
+        assert result == "survived"

--- a/tests/test_unified_parser_router.py
+++ b/tests/test_unified_parser_router.py
@@ -1,0 +1,179 @@
+"""
+Tests for codecarto.routers.unified_parser_router:
+  - _stream_cached_graph: the single shared SSE cache-replay generator used
+    by both POST /parse/stream and POST /parse/stream-url. Before this it
+    was two ~25-line near-identical inner functions (stream_cached /
+    stream_cached_url) — extracted so the two endpoints can't silently
+    drift from each other on the next edit. Mirrors the frontend's
+    PlotService._consumeSSE(), which already serves as the one shared
+    parser for streamUnified/streamFromUrl/streamCGithub.
+"""
+
+import json
+
+import pytest
+from fastapi.testclient import TestClient
+
+from codecarto.main import app
+from codecarto.routers.unified_parser_router import _stream_cached_graph
+from codecarto.services.cache_service import CacheService
+
+
+def _parse_sse_chunk(chunk: str) -> tuple[str, dict]:
+    lines = chunk.strip().split("\n")
+    event_type = lines[0].split("event: ", 1)[1]
+    data_line = next(l for l in lines if l.startswith("data: "))
+    return event_type, json.loads(data_line[len("data: "):])
+
+
+async def _collect(cached: dict, layout: str = "Spring") -> list[tuple[str, dict]]:
+    events = []
+    async for chunk in _stream_cached_graph(cached, layout):
+        events.append(_parse_sse_chunk(chunk))
+    return events
+
+
+class TestStreamCachedGraph:
+    @pytest.mark.asyncio
+    async def test_event_order_meta_nodes_edges_done(self):
+        cached = {
+            "graph": {
+                "nodes": {
+                    "file::a.py": {"metadata": {"depth": 1, "kind": "file", "label": "a.py"}},
+                    "fn::a.foo": {"metadata": {"depth": 2, "kind": "function", "label": "foo"}},
+                },
+                "edges": [{"source": "file::a.py", "target": "fn::a.foo", "kind": "contains"}],
+            }
+        }
+        events = await _collect(cached)
+        types = [t for t, _ in events]
+        assert types == ["meta", "node", "node", "edge", "done"]
+
+    @pytest.mark.asyncio
+    async def test_nodes_sorted_by_depth_then_id(self):
+        cached = {
+            "graph": {
+                "nodes": {
+                    "fn::a.foo": {"metadata": {"depth": 2, "kind": "function", "label": "foo"}},
+                    "file::a.py": {"metadata": {"depth": 1, "kind": "file", "label": "a.py"}},
+                },
+                "edges": [],
+            }
+        }
+        events = await _collect(cached)
+        node_ids = [d["id"] for t, d in events if t == "node"]
+        assert node_ids == ["file::a.py", "fn::a.foo"]
+
+    @pytest.mark.asyncio
+    async def test_meta_and_done_marked_from_cache(self):
+        cached = {"graph": {"nodes": {}, "edges": []}}
+        events = await _collect(cached, layout="Spectral")
+
+        meta = next(d for t, d in events if t == "meta")
+        done = next(d for t, d in events if t == "done")
+        assert meta["from_cache"] is True
+        assert meta["layout"] == "Spectral"
+        assert done["from_cache"] is True
+
+    @pytest.mark.asyncio
+    async def test_counts_match_actual_nodes_and_edges(self):
+        cached = {
+            "graph": {
+                "nodes": {
+                    "a": {"metadata": {"depth": 1, "label": "a"}},
+                    "b": {"metadata": {"depth": 1, "label": "b"}},
+                },
+                "edges": [{"source": "a", "target": "b", "kind": "contains"}],
+            }
+        }
+        events = await _collect(cached)
+        meta = next(d for t, d in events if t == "meta")
+        assert meta["nodeCount"] == 2
+        assert meta["edgeCount"] == 1
+
+    @pytest.mark.asyncio
+    async def test_non_dict_node_entries_are_skipped(self):
+        """Defensive: a malformed cache entry (corrupted JSON value) must not
+        crash the replay, just be skipped."""
+        cached = {
+            "graph": {
+                "nodes": {"a": {"metadata": {"depth": 1, "label": "a"}}, "b": "not-a-dict"},
+                "edges": [],
+            }
+        }
+        events = await _collect(cached)
+        node_ids = [d["id"] for t, d in events if t == "node"]
+        assert node_ids == ["a"]
+
+    @pytest.mark.asyncio
+    async def test_node_attrs_flattened_with_metadata_priority(self):
+        """Top-level attrs (e.g. x/y from some gravis versions) come first,
+        metadata attrs (depth/kind/...) override/supplement them."""
+        cached = {
+            "graph": {
+                "nodes": {"a": {"x": 1.0, "y": 2.0, "metadata": {"depth": 1, "label": "a"}}},
+                "edges": [],
+            }
+        }
+        events = await _collect(cached)
+        node = next(d for t, d in events if t == "node")
+        assert node["x"] == 1.0
+        assert node["y"] == 2.0
+        assert node["depth"] == 1
+        assert node["label"] == "a"
+
+    @pytest.mark.asyncio
+    async def test_empty_graph_still_yields_meta_and_done(self):
+        cached = {"graph": {}}
+        events = await _collect(cached)
+        types = [t for t, _ in events]
+        assert types == ["meta", "done"]
+
+
+class TestStreamEndpointsShareCacheReplay:
+    """The actual point of the extraction: /parse/stream and
+    /parse/stream-url must produce byte-for-byte identical SSE output for
+    the same cached entry — proving they share _stream_cached_graph rather
+    than two independently-maintained copies."""
+
+    @pytest.fixture()
+    def client(self):
+        return TestClient(app)
+
+    def test_stream_and_stream_url_identical_on_cache_hit(self, client, monkeypatch, tmp_path):
+        cache_dir = tmp_path / "cache"
+        repos_dir = cache_dir / "repos"
+        import codecarto.services.cache_service as cache_svc
+        monkeypatch.setattr(cache_svc, "_CACHE_DIR", cache_dir)
+        monkeypatch.setattr(cache_svc, "_REPOS_DIR", repos_dir)
+        monkeypatch.setattr(cache_svc, "_INDEX_FILE", repos_dir / "index.json")
+
+        url = "https://github.com/test/shared-replay"
+        graph_data = {
+            "graph": {
+                "nodes": {"file::a.py": {"metadata": {"depth": 1, "kind": "file", "label": "a.py"}}},
+                "edges": [],
+            },
+            "metadata": {},
+        }
+        key = CacheService.cache_key(url, "2", "Spring", [])
+        CacheService.set(key, graph_data, label="test/shared-replay", url=url, mode="2", layout="Spring")
+
+        body_stream = {
+            "directory": {
+                "info": {"url": url, "owner": "test", "name": "shared-replay"},
+                "size": 0,
+                "root": {"name": "", "size": 0, "files": [], "folders": []},
+                "is_partial": False,
+            },
+            "depth": 2,
+            "layout": "Spring",
+        }
+        body_stream_url = {"url": url, "depth": 2, "layout": "Spring"}
+
+        resp_a = client.post("/parse/stream", json=body_stream)
+        resp_b = client.post("/parse/stream-url", json=body_stream_url)
+
+        assert resp_a.status_code == 200
+        assert resp_b.status_code == 200
+        assert resp_a.text == resp_b.text

--- a/tests/test_unified_parser_service.py
+++ b/tests/test_unified_parser_service.py
@@ -619,6 +619,75 @@ class TestStreamParseUrlDependencyEdges:
         assert not any(t == "edge" and d.get("kind") == "depends_on" for t, d in events)
 
 
+# ── _split_by_batch_mode: pure grouping helper, shared by both dispatch sites ──
+# Extracted so the GitHub-streaming path (stream_parse_url) and the
+# local-directory path (_walk_folder) don't each reimplement "group by
+# whether this item's parser wants batch_whole_tree" independently. Tested
+# directly here since it's pure (no I/O, no closures) — the end-to-end
+# behavior it enables is covered separately by TestCBatchWholeTree below.
+
+class TestSplitByBatchMode:
+    def _ext_of_name(self, item: str) -> str:
+        return "." + item.rsplit(".", 1)[-1].lower()
+
+    def test_python_files_go_to_per_item(self):
+        import codecarto.services.parsers.python_language_parser  # noqa: F401 (registers .py)
+        from codecarto.services.unified_parser_service import _split_by_batch_mode
+
+        per_item, batched = _split_by_batch_mode(["a.py", "b.py"], self._ext_of_name)
+
+        assert batched == {}
+        assert {item for item, _ in per_item} == {"a.py", "b.py"}
+
+    def test_c_files_go_to_batched_grouped_by_parser_identity(self):
+        # No libclang needed here — CLangaugeParser registers itself with
+        # ParserRegistry at import time regardless of whether libclang is
+        # installed; only parse_files() itself lazily needs it.
+        import codecarto.services.parsers.c_language_parser as clp
+        from codecarto.services.unified_parser_service import _split_by_batch_mode
+
+        per_item, batched = _split_by_batch_mode(["a.c", "b.h"], self._ext_of_name)
+
+        assert per_item == []
+        assert len(batched) == 1
+        parser, items = next(iter(batched.values()))
+        assert isinstance(parser, clp.CLangaugeParser)
+        assert set(items) == {"a.c", "b.h"}
+
+    def test_unregistered_extension_is_dropped(self):
+        from codecarto.services.unified_parser_service import _split_by_batch_mode
+
+        per_item, batched = _split_by_batch_mode(["data.csv"], self._ext_of_name)
+
+        assert per_item == []
+        assert batched == {}
+
+    def test_mixed_extensions_split_correctly(self):
+        import codecarto.services.parsers.python_language_parser  # noqa: F401
+        import codecarto.services.parsers.c_language_parser  # noqa: F401
+        from codecarto.services.unified_parser_service import _split_by_batch_mode
+
+        per_item, batched = _split_by_batch_mode(
+            ["a.py", "b.c", "c.py", "d.h"], self._ext_of_name
+        )
+
+        assert {item for item, _ in per_item} == {"a.py", "c.py"}
+        assert len(batched) == 1
+        _, items = next(iter(batched.values()))
+        assert set(items) == {"b.c", "d.h"}
+
+    def test_same_parser_instance_across_calls_groups_together(self):
+        """.c and .h are different extensions but the SAME CLangaugeParser
+        instance — must land in one batch group, not two (matches the
+        existing batch_whole_tree id(parser)-keying convention)."""
+        import codecarto.services.parsers.c_language_parser  # noqa: F401
+        from codecarto.services.unified_parser_service import _split_by_batch_mode
+
+        _, batched = _split_by_batch_mode(["x.c", "y.h", "z.c"], self._ext_of_name)
+
+        assert len(batched) == 1
+
+
 # ── batch_whole_tree: C files parsed together, not one-at-a-time ──────────────
 # Before this, _walk_folder dispatched parser.parse_files([file], depth) one
 # file at a time for every language. Fine for Python; structurally wrong for

--- a/web/src/services/plot_service.ts
+++ b/web/src/services/plot_service.ts
@@ -91,36 +91,6 @@ export class PlotService {
     return null;
   }
 
-  /** Parse a C/C++ file via the c-parser backend endpoint. */
-  public static async plotCFile(
-    cParserUrl: string,
-    path: string
-  ): Promise<unknown> {
-    const url = `${cParserUrl}/file`;
-    const body = { path };
-    const data = await RequestHandler.postRequest(url, body);
-    if (typeof data === 'string') {
-      logger.error('Error plotCFile');
-      return null;
-    }
-    return data;
-  }
-
-  /** Parse a C/C++ directory via the c-parser backend endpoint. */
-  public static async plotCDirectory(
-    cParserUrl: string,
-    path: string
-  ): Promise<unknown> {
-    const url = `${cParserUrl}/directory`;
-    const body = { path };
-    const data = await RequestHandler.postRequest(url, body);
-    if (typeof data === 'string') {
-      logger.error('Error plotCDirectory');
-      return null;
-    }
-    return data;
-  }
-
   /** Fetch the registered language extensions from the backend. */
   public static async fetchLanguages(
     parseUrl: string

--- a/web/src/state/actions.ts
+++ b/web/src/state/actions.ts
@@ -9,42 +9,6 @@ import { Directory, RawFile, RawFolder, RepoInfo } from '../components/models/so
 import { logger } from '../core/logger';
 
 /**
- * Adapt the flat {nodes, edges, meta} shape returned by the C parser backend
- * into the gJGF {graph: {nodes, edges}, metadata} shape that GraphData and
- * the D3 renderer expect. Also remaps edge keys src/dst → source/target.
- */
-function adaptCGraphToGJGF(raw: Record<string, unknown>): GraphData {
-  const nodes = (raw.nodes as Record<string, unknown>[]) ?? [];
-  const rawEdges = (raw.edges as Record<string, unknown>[]) ?? [];
-  const meta = (raw.meta as Record<string, unknown>) ?? {};
-
-  // D3 forceLink throws "node not found" if any edge references an unknown ID.
-  // The C parser can produce edges to nodes outside the target file set (e.g.
-  // a FIELD_OF edge whose parent struct lives in a system header). Filter them.
-  const nodeIds = new Set(nodes.map(n => n.id as string));
-  const edges = rawEdges
-    .filter(e => nodeIds.has(e.src as string) && nodeIds.has(e.dst as string))
-    .map(e => ({
-      source: e.src as string,
-      target: e.dst as string,
-      label:  e.kind as string,
-      weight: e.weight,
-    }));
-
-  return {
-    graph: { nodes, edges, directed: true },
-    metadata: {
-      layout:     'force',
-      type:       'c',
-      nodeCount:  nodes.length,
-      edgeCount:  edges.length,
-      palette_id: 'default',
-      ...meta,
-    },
-  } as unknown as GraphData;
-}
-
-/**
  * Convert frontend layout format to backend format
  * Frontend: 'spring_layout', 'spectral_layout', etc.
  * Backend: 'Spring', 'Spectral', 'Kamada_Kawai', etc.
@@ -468,46 +432,6 @@ export class PlotActions {
   }
 
   /**
-   * Parse a C/C++ file at the given local path using the c-parser backend
-   */
-  async plotCFile(path: string): Promise<void> {
-    this.stateController.clear();
-    try {
-      const data = await PlotService.plotCFile(
-        this.stateController.api.cParser,
-        path
-      );
-      if (!data) throw new Error('No data returned from c-parser');
-      const result = (data as Record<string, unknown>);
-      const raw = (result['graph'] ?? data) as Record<string, unknown>;
-      this.handlePlotData(adaptCGraphToGJGF(raw));
-    } catch (error) {
-      console.error('Failed to plot C file:', error);
-      throw error;
-    }
-  }
-
-  /**
-   * Parse a C/C++ directory at the given local path using the c-parser backend
-   */
-  async plotCDirectory(path: string): Promise<void> {
-    this.stateController.clear();
-    try {
-      const data = await PlotService.plotCDirectory(
-        this.stateController.api.cParser,
-        path
-      );
-      if (!data) throw new Error('No data returned from c-parser');
-      const result = (data as Record<string, unknown>);
-      const raw = (result['graph'] ?? data) as Record<string, unknown>;
-      this.handlePlotData(adaptCGraphToGJGF(raw));
-    } catch (error) {
-      console.error('Failed to plot C directory:', error);
-      throw error;
-    }
-  }
-
-  /**
    * Parse a directory using the unified schema (depth-based hierarchy).
    * Any renderer (D3, Gravis, …) can display the result.
    */
@@ -674,41 +598,6 @@ export class UploadActions {
   selectFile(file: RawFile): void {
     this.stateController.setSelectedLocalFile(file);
   }
-
-  /**
-   * Clear uploaded files
-   */
-  clearUploads(): void {
-    this.stateController.clearLocalData();
-  }
-}
-
-/**
- * UI Actions - handles UI state changes
- */
-export class UIActions {
-  constructor(private stateController: StateController) {}
-
-  /**
-   * Toggle the control panel visibility
-   */
-  toggleControlPanel(): void {
-    // Would need to add this to state controller
-  }
-
-  /**
-   * Set the active control panel tab
-   */
-  setActiveTab(tab: 'demo' | 'repo' | 'upload' | 'settings'): void {
-    // Would need to add this to state controller
-  }
-
-  /**
-   * Clear any error state
-   */
-  clearError(): void {
-    // Would need to add this to state controller
-  }
 }
 
 /**
@@ -718,7 +607,6 @@ export interface AppActions {
   plot: PlotActions;
   repo: RepoActions;
   upload: UploadActions;
-  ui: UIActions;
 }
 
 /**
@@ -729,6 +617,5 @@ export function createActions(stateController: StateController): AppActions {
     plot: new PlotActions(stateController),
     repo: new RepoActions(stateController),
     upload: new UploadActions(stateController),
-    ui: new UIActions(stateController),
   };
 }

--- a/web/src/state/index.ts
+++ b/web/src/state/index.ts
@@ -23,7 +23,6 @@ export {
   PlotActions, 
   RepoActions, 
   UploadActions, 
-  UIActions, 
   createActions,
   type AppActions 
 } from './actions';


### PR DESCRIPTION
## Summary

Per request: checked out PR #70 (`copilot-swe-agent`'s
`copilot/frontend-integration-golden-layout`), verified its "followups"
commit against the survey doc, then implemented the rest.

### PR #70 review findings

PR #70's `d0e685f` commit claims 1.2, 1.3, 2.1, and 2.3 from
[`parser_consolidation_and_scope_drift.md`](docs/llm/next_steps/parser_consolidation_and_scope_drift.md).
All four are **correct and working** — verified by:
- Live-testing 1.3 (C project-root parity) against a real multi-directory C project: confirmed the old code fails to resolve a root-level header from a nested source file, the new code resolves it and produces the expected cross-file `calls` edge.
- Running the full existing test suite against the PR branch (267 passed, no regressions).
- Confirming the 2.3 dead-code removal left zero dangling references (grep) and the frontend still builds.
- Reading 2.1's extraction — clean, byte-for-byte equivalent.

**However**: the PR added **zero tests** for any of the four items, and the branch also carries an unrelated "Golden Layout frontend integration" mixed into the same history (first 2 commits + a later one from you). Given that, I cherry-picked just the followups commit (`d0e685f`) onto a clean branch off `caching-and-parser-consolidation`, rather than basing this on PR #70's branch directly.

### What this PR adds

1. **Tests for PR #70's work** — `test_c_parser_service.py` (1.3, including the single-file `commonpath` edge case), `test_unified_parser_service.py` (1.2, pure unit tests), new `test_unified_parser_router.py` (2.1 — including an end-to-end test proving `/parse/stream` and `/parse/stream-url` now produce byte-for-byte identical cached output, the actual point of that extraction).
2. **1.4** — `Folder.iter_files()` shared traversal helper, applied to the 3 genuinely-matching call sites. Deliberately left `_walk_folder`'s own recursion alone (it builds graph state per-level, not a flat list — a worse fit than the doc implied).
3. **2.2** — new `codecarto/util/threaded_feeder.py`, `start_threaded_feeder(worker_factory)`, applied to both `c_parser_router.py`'s `/stream-github` and `pam_router.py`'s log tailer. Live-verified `on_pam_startup()` against a real log file and the "no log available" fallback path.

Every item in the survey doc is now marked done with what was actually verified — see the doc for full detail per item.

## Test plan

- [x] Full backend suite: 293 passed (267 baseline + 26 new)
- [x] Frontend build (`npm run build`) passes
- [x] Live verification: 1.3's C include-resolution fix (before/after, real multi-directory project); 1.2/2.1 via direct unit tests on the pure functions; `on_pam_startup()` against a real `PAM_LOG_FILE` and the no-log-found path
- [ ] No frontend test suite exists in this repo to run (`web/` has no test script) — relied on `npm run build` + the existing dead-code grep

## Note on PR #70

This PR's base is `caching-and-parser-consolidation`, the same base PR #70 targets — once this merges, PR #70's `d0e685f` commit becomes redundant for the parts covered here (1.2/1.3/2.1/2.3). Its Golden Layout work is unaffected and would need to be rebased/cleaned up separately; that's outside this PR's scope.