### PR TITLE
fix: gh CLI keyring-first token resolution + View Source on streaming renderer

### DIFF
--- a/codecarto/main.py
+++ b/codecarto/main.py
@@ -78,7 +78,21 @@ async def root():
     return RedirectResponse(url="/docs")
 
 
+@app.get("/auth/github", tags=["auth"])
+async def github_auth_status_endpoint():
+    """Report the active GitHub credential source and whether a token is present.
+
+    Useful for diagnosing the env-var / gh-CLI keyring precedence issue:
+    a stale GITHUB_TOKEN silently shadows a valid gh keyring token unless
+    CC_GITHUB_TOKEN is set or GITHUB_TOKEN/GH_TOKEN are cleared.
+    """
+    from codecarto.services.github_service import github_auth_status
+    return github_auth_status()
+
+
 @app.on_event("startup")
 async def startup():
     from codecarto.routers.pam_router import on_pam_startup
+    from codecarto.services.github_service import get_github_token
+    get_github_token()  # resolve and log the auth source at startup
     await on_pam_startup()

--- a/codecarto/routers/repo_router.py
+++ b/codecarto/routers/repo_router.py
@@ -8,7 +8,8 @@ from codecarto.services.github_service import (
     create_headers,
     get_subtree,
     expand_all_tree,
-    is_github_url
+    is_github_url,
+    get_github_token,
 )
 from codecarto.services.local_repo_service import get_local_repo
 from codecarto.util.exceptions import CodeCartoException, proc_exception
@@ -85,7 +86,7 @@ async def expand_all_repo(url: str, max_depth: int = 3) -> dict:
                 pass  # corrupt cache entry — fall through to live fetch
 
         owner, repo_name = get_owner_repo_from_url(url)
-        token = os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN")
+        token = get_github_token()
         root_folder = await expand_all_tree(owner, repo_name, token, max_depth)
         root_folder.name = f"{owner}/{repo_name}"
         info = RepoInfo(owner=owner, name=repo_name, url=url)

--- a/codecarto/services/github_service.py
+++ b/codecarto/services/github_service.py
@@ -1,4 +1,7 @@
 import asyncio
+import logging
+import os
+import subprocess
 import httpx
 from pathlib import Path
 from codecarto.models.source_data import Directory, File, Folder, RepoInfo
@@ -442,34 +445,105 @@ def get_owner_repo_from_url(url: str) -> tuple[str, str]:
     return parts[3], parts[4]
 
 
+_log = logging.getLogger(__name__)
+
+# ── GitHub token resolution ─────────────────────────────────────────────────
+# Resolved once at startup via resolve_github_token(); cached here so every
+# API request reuses it without re-running the subprocess.
+_github_token: str | None = None
+_github_token_source: str = "none"
+
+
+def resolve_github_token() -> tuple[str | None, str]:
+    """Resolve the best available GitHub token and name the source.
+
+    Resolution order (first non-empty string wins):
+
+    1. CC_GITHUB_TOKEN — project-specific env var that can be set
+       independently of the system GITHUB_TOKEN, so it never conflicts
+       with a stale gh-cli GITHUB_TOKEN.
+
+    2. gh auth token (keyring) — `gh auth token --hostname github.com`
+       invoked with GITHUB_TOKEN and GH_TOKEN stripped from the subprocess
+       environment so the gh CLI uses its keyring credential rather than
+       the (potentially stale) env var.
+
+    3. GITHUB_TOKEN env var — legacy / Docker Compose pass-through.
+
+    4. GH_TOKEN env var — alternative legacy name.
+
+    5. Docker secrets file — /run/secrets/github_token.
+
+    6. None — unauthenticated; rate-limited to 60 req/h per IP.
+
+    Returns (token_or_None, source_label).
+    """
+    # 1. Explicit project override
+    if token := os.environ.get("CC_GITHUB_TOKEN", "").strip():
+        return token, "CC_GITHUB_TOKEN env var"
+
+    # 2. gh CLI keyring — strip GITHUB_TOKEN/GH_TOKEN so gh uses keyring
+    try:
+        env_without_token = {
+            k: v for k, v in os.environ.items()
+            if k not in ("GITHUB_TOKEN", "GH_TOKEN")
+        }
+        result = subprocess.run(
+            ["gh", "auth", "token", "--hostname", "github.com"],
+            capture_output=True, text=True, timeout=5, env=env_without_token,
+        )
+        if result.returncode == 0 and (token := result.stdout.strip()):
+            return token, "gh CLI keyring"
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        pass  # gh not installed or timed out
+
+    # 3 & 4. Env vars (legacy / Docker Compose)
+    if token := (os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN") or "").strip():
+        return token, "GITHUB_TOKEN/GH_TOKEN env var"
+
+    # 5. Docker secrets
+    try:
+        token = Path("/run/secrets/github_token").read_text().strip()
+        if token:
+            return token, "Docker secret"
+    except (FileNotFoundError, PermissionError):
+        pass
+
+    # 6. Unauthenticated
+    return None, "none (unauthenticated)"
+
+
+def get_github_token() -> str | None:
+    """Return the cached GitHub token, resolving it on first call."""
+    global _github_token, _github_token_source
+    if _github_token is None and _github_token_source == "none":
+        _github_token, _github_token_source = resolve_github_token()
+        if _github_token:
+            _log.info("GitHub auth: %s (token: %s…)", _github_token_source, _github_token[:8])
+        else:
+            _log.warning(
+                "GitHub auth: unauthenticated — rate-limited to 60 req/h per IP. "
+                "Set CC_GITHUB_TOKEN or run 'gh auth login'."
+            )
+    return _github_token
+
+
+def github_auth_status() -> dict:
+    """Return a dict describing the current GitHub auth state (for /auth/github)."""
+    get_github_token()  # ensure resolved
+    return {
+        "source": _github_token_source,
+        "authenticated": _github_token is not None,
+        "token_prefix": _github_token[:8] + "…" if _github_token else None,
+    }
+
+
 def create_headers(url: str) -> dict:
-    """Create headers for GitHub API request with optional authorization token."""
-    import os
-
-    # Try multiple sources for GitHub token (in order of priority):
-    # 1. Environment variable
-    # 2. Docker secrets file
-    # 3. No token (unauthenticated - limited rate)
-    GIT_API_KEY = None
-
-    # Try environment variable first
-    GIT_API_KEY = os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN")
-
-    # Try Docker secrets file if env var not found
-    if not GIT_API_KEY:
-        try:
-            with open("/run/secrets/github_token", "r") as file:
-                GIT_API_KEY = file.read().strip()
-        except (FileNotFoundError, PermissionError):
-            pass  # File doesn't exist or can't be read - will use unauthenticated
-
-    # Build headers
+    """Build GitHub API request headers using the resolved token."""
     headers = {"Accept": "application/vnd.github.v3+json"}
-
-    # Add authorization if token found
-    if GIT_API_KEY:
-        headers["Authorization"] = f"token {GIT_API_KEY}"
-
+    token = get_github_token()
+    if token:
+        headers["Authorization"] = f"token {token}"
     return headers
 
 

--- a/docs/adr/DRAFT-github-token-resolution.md
+++ b/docs/adr/DRAFT-github-token-resolution.md
@@ -1,0 +1,105 @@
+# ADR-XXXX — GitHub token resolution order: gh CLI keyring primary, env vars secondary
+
+| | |
+|---|---|
+| **Status** | Proposed |
+| **Date** | 2026-06-30 |
+| **Pends on** | Integration test: verify `gh auth status` reports the keyring account as active after the fix |
+
+## Context
+
+`github_service.py`'s `create_headers()` read `GITHUB_TOKEN` first. The
+`gh` CLI also reads `GITHUB_TOKEN` first when resolving credentials. The
+result: a stale or expired `GITHUB_TOKEN` env var shadowed a valid
+`gh` keyring credential at every level simultaneously — neither the
+backend's `httpx` calls nor the `gh pr create` CLI command could reach
+GitHub, even with `gh auth login` confirmed and a valid keyring token
+present. `gh auth status` reported:
+
+```
+X Failed to log in to github.com using token (GITHUB_TOKEN)
+  - Active account: true          # <- the bad env var is "active"
+
+✓ Logged in to github.com account subcontrabass (keyring)
+  - Active account: false         # <- the good keyring token is inactive
+```
+
+The same carousel recurred multiple times during this project's history
+because clearing a system env var is not durable — it must be re-cleared
+in every new shell session.
+
+## Decision
+
+Introduce `resolve_github_token()` in `github_service.py`, called once
+at startup and cached. The resolution order is:
+
+1. **`CC_GITHUB_TOKEN` env var** — project-specific override. Using a
+   namespaced variable avoids any conflict with system-level or CI
+   `GITHUB_TOKEN` variables set for other tooling.
+
+2. **`gh auth token --hostname github.com`** (keyring) — `gh` is invoked
+   in a subprocess with `GITHUB_TOKEN` and `GH_TOKEN` stripped from its
+   environment, so it uses the keyring credential rather than the (possibly
+   stale) env var. Timeout is 5 s; if `gh` is not installed this source
+   is skipped silently.
+
+3. **`GITHUB_TOKEN` / `GH_TOKEN` env vars** — legacy / Docker Compose
+   pass-through. Still supported, but now at lower priority so a bad value
+   does not shadow a valid keyring token.
+
+4. **Docker secret** — `/run/secrets/github_token`.
+
+5. **Unauthenticated** — 60 req/h per IP; logs a warning at startup.
+
+`get_github_token()` returns the cached result; `create_headers()` calls
+it. `repo_router.py`'s direct `os.environ.get("GITHUB_TOKEN")` call is
+replaced with `get_github_token()` to close a second bypass path.
+
+A `GET /auth/github` endpoint returns `{source, authenticated, token_prefix}`
+so the current resolution is inspectable without reading server logs. The
+frontend header shows a coloured GH indicator (green = authenticated,
+amber = unauthenticated) with a tooltip naming the source.
+
+## Consequences
+
+- Developers who `gh auth login` and do nothing else get authenticated
+  API access automatically. The "carousel of env vars" described in the
+  project history is eliminated for local dev.
+- Docker Compose and CI still work: set `CC_GITHUB_TOKEN` (preferred) or
+  `GITHUB_TOKEN` (legacy); both are resolved in the expected way without
+  `gh` installed.
+- Token caching at module level means a token that expires mid-run will
+  produce 401s until the process is restarted. The existing `_api_get`
+  retry (strips auth and retries on 401) prevents hard failures for public
+  repos — private repos would fail until restart. This is accepted: tokens
+  typically last 8 h–1 year; a restart is the expected recovery.
+- `gh` must be on `PATH` for source 2 to activate. If `gh` is absent,
+  resolution falls through to env vars. No new hard dependency.
+
+## Alternatives considered
+
+1. **Fix by deleting `GITHUB_TOKEN` from the shell environment** — not
+   durable; the problem recurs in every new shell session or after a
+   system update sets the variable again.
+2. **Replace all `httpx` GitHub calls with `gh api` subprocess calls** —
+   `gh` handles auth automatically and completely; rejected as too invasive
+   for this codebase's async architecture (blocking subprocess per API call
+   inside async routes).
+3. **Validate `GITHUB_TOKEN` against `/user` before using it** — adds
+   an extra network round-trip on every startup even when the token is
+   good; the keyring-first approach avoids the bad token entirely rather
+   than detecting it after the fact.
+
+## Revision triggers
+
+- The token expiry / mid-run 401 failure rate becomes a real complaint
+  (e.g., from long-running server deployments) — implement a background
+  refresh or a cache TTL with re-resolution.
+- A second VCS host (GitLab, Bitbucket) is supported — generalize
+  `resolve_github_token()` into a per-host resolver.
+- `gh` auth token output format changes — watch for `gh` major version
+  bumps.
+
+## Amendments
+
+*None.*

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -101,3 +101,4 @@ Drafts in flight (numberless, by title):
 - *Wire graphbase as a named bookmark store via /db/bookmarks* — `DRAFT-graphbase-bookmark-integration.md`
 - *Formalize the graphbase submodule interface; keep it a submodule* — `DRAFT-graphbase-submodule-interface-contract.md`
 - *Code-map navigation: source-ordered layout, depth-4 hierarchy, view-source* — `DRAFT-code-map-navigation.md`
+- *GitHub token resolution order: gh CLI keyring primary, env vars secondary* — `DRAFT-github-token-resolution.md`

--- a/docs/api.md
+++ b/docs/api.md
@@ -508,6 +508,90 @@ Stream real-time PAM events as JSON objects:
 
 ---
 
+## Auth Endpoints
+
+### GET `/auth/github`
+
+Report the active GitHub credential source and whether the backend has a
+valid token. Useful for diagnosing the `GITHUB_TOKEN`-vs-keyring shadowing
+issue described in *GitHub token resolution order* (`docs/adr/`).
+
+**Response:**
+```json
+{
+  "source": "gh CLI keyring",
+  "authenticated": true,
+  "token_prefix": "gho_Ccw0…"
+}
+```
+
+`source` is one of: `"CC_GITHUB_TOKEN env var"`, `"gh CLI keyring"`,
+`"GITHUB_TOKEN/GH_TOKEN env var"`, `"Docker secret"`, or
+`"none (unauthenticated)"`.
+
+---
+
+## Graphbase Endpoints (`/db/*`)
+
+Mounted **only** when `MONGODB_URI` env var is set. All routes return 404
+otherwise. See `docs/adr/DRAFT-cache-service-vs-graphbase.md` for why this
+store is separate from the filesystem `CacheService`.
+
+The graphbase submodule exposes three typed collections:
+
+| Collection | Purpose | Key |
+|------------|---------|-----|
+| `graph` | Named NetworkX graphs (legacy nx.node_link_data format) | `name` |
+| `snapshots` | Full rendered graph snapshots (gJGF nodes + edges, instant replay) | `name` |
+| `bookmarks` | Lightweight URL + parse-settings records (re-streams on load) | `name` |
+| `history` | Per-URL render history, capped at 20 entries per URL | `(url_hash, captured_at)` |
+
+### Bookmarks
+
+#### POST `/db/bookmarks?name=&url=&layout=&depth=&extensions=`
+Save or overwrite a named source bookmark. Returns `{"message":"Bookmark saved","name":"..."}`.
+
+#### GET `/db/bookmarks`
+List all saved bookmarks. Returns an array of `{name, url, layout, depth, extensions, saved_at}` objects.
+
+#### DELETE `/db/bookmarks/{name}`
+Delete a named bookmark. Returns 404 if not found.
+
+### Snapshots
+
+#### POST `/db/snapshots?name=`
+Body: `{nodes, edges, meta}` in gJGF-adjacent format. Upserts a named graph
+snapshot for instant replay — no re-streaming required. Computed fields
+(`name`, `saved_at`) cannot be overridden by body content.
+
+#### GET `/db/snapshots`
+List snapshot metadata (excludes the full nodes/edges payloads).
+
+#### GET `/db/snapshots/{name}`
+Retrieve a full snapshot including nodes and edges.
+
+#### DELETE `/db/snapshots/{name}`
+Delete a named snapshot.
+
+### History
+
+#### POST `/db/history?url=`
+Body: `{nodes, edges, meta}`. Append a render snapshot for the given URL.
+The backend assigns `url_hash` (SHA-256(url)[:16]) and `captured_at` (unix
+timestamp). Entries are capped at 20 per URL; oldest are pruned automatically.
+Computed fields cannot be overridden by body content.
+
+#### GET `/db/history/{url_hash}`
+List history metadata for a URL hash (no node/edge payloads).
+
+#### GET `/db/history/{url_hash}/{captured_at}`
+Retrieve a specific history entry (full data).
+
+#### DELETE `/db/history/{url_hash}/{captured_at}`
+Delete a specific history entry.
+
+---
+
 ## Palette Endpoints
 
 ### GET `/palette/list`

--- a/docs/llm/ARCHITECTURE.md
+++ b/docs/llm/ARCHITECTURE.md
@@ -563,6 +563,89 @@ Labels appear near the top edge of each circle. All circles fade in (300ms delay
 
 ---
 
+## GitHub Token Resolution
+
+`github_service.resolve_github_token()` is called once at startup and cached.
+Resolution order:
+
+1. `CC_GITHUB_TOKEN` env var — project-specific, won't conflict with system
+   `GITHUB_TOKEN` set by other tooling.
+2. `gh auth token --hostname github.com` in a subprocess with `GITHUB_TOKEN`
+   and `GH_TOKEN` **stripped** from the subprocess environment, so the `gh`
+   keyring credential is used rather than a stale env var.
+3. `GITHUB_TOKEN` / `GH_TOKEN` env var — legacy / Docker Compose pass-through.
+4. Docker secret at `/run/secrets/github_token`.
+5. Unauthenticated (60 req/h per IP; logs a warning).
+
+**Why this order matters:** a stale `GITHUB_TOKEN` in the environment would
+shadow a valid `gh` keyring token at every level if env vars were checked
+first. See *GitHub token resolution order* (`docs/adr/`) for the full
+rationale.
+
+`GET /auth/github` exposes the resolved source for diagnostics. The GL header
+shows a green/amber GH indicator on page load.
+
+> **For local dev:** run `gh auth login` once. Set `MONGODB_URI` in the same
+> shell that starts the server. Do not set `GITHUB_TOKEN` in `.bashrc` — use
+> `CC_GITHUB_TOKEN` if you need an explicit token override that won't shadow
+> the `gh` keyring.
+
+---
+
+## Graphbase Store (`/db/*`)
+
+MongoDB-backed named-graph store, mounted only when `MONGODB_URI` is set.
+Distinct from `CacheService` — see *CacheService and graphbase stay separate
+stores* (`docs/adr/`).
+
+Four collections in the `graphbase` database:
+
+| Collection | What it holds | Key | Eviction |
+|------------|--------------|-----|----------|
+| `graph` | Named NetworkX graphs (nx.node_link_data) | `name` | Manual |
+| `snapshots` | Full rendered graph (gJGF nodes + edges) | `name` | Manual |
+| `bookmarks` | URL + parse settings; re-streams on load | `name` | Manual |
+| `history` | Per-URL render snapshots, opt-in | `(url_hash, captured_at)` | Auto, cap 20/URL |
+
+The frontend Graph Library panel (graphbase_panel.ts) exposes all four tiers
+in one view:
+- **Snapshots** — 📸 saves the live rendered graph; ▶ replays instantly
+  (no re-parse) via `LayoutContext.loadGraphbaseSnapshot`.
+- **Saved** — ☆ bookmarks a URL; ▶ re-streams; ★ on Recent entries that
+  are already bookmarked.
+- **History** — auto-appended when "Track" is on; oldest pruned at cap;
+  ▶ replays any past version.
+- **Recent** — the existing CacheService entries with ☆ promote-to-bookmark.
+
+The graphbase package is a git submodule at `graphbase/`. Its public surface
+is `graphbase/__init__.py` which re-exports `graphdb` (FastAPI router) and
+`get_db` (lazy MongoClient) from `graphbase.src.main`. Callers in
+`codecarto/` import from `from graphbase import graphdb, get_db` — not from
+the internal sub-path.
+
+---
+
+## Code-Map Layout
+
+The compound hierarchical layout is now four passes and source-order-aware:
+
+- **Pass 1** — directory spring layout, X-biased (x_stretch=1.6, y_stretch=0.7)
+- **Pass 2** — files orbit parent dir in equal-angle ring
+- **Pass 3** — depth-2 symbols placed in a **300° source-ordered arc** around
+  their file (sorted by `line` attribute, 12-o'clock = line 1 → clockwise =
+  later lines). Each file cluster reads like a minimap of the source file.
+- **Pass 4** — depth-3 sub-symbols orbit their nearest depth-2 parent symbol
+  in the same arc convention.
+
+`computeChildrenMap` in `compound_layout.ts` covers all four tiers for drag
+propagation; dragging any node moves its entire transitive subtree.
+
+Right-clicking a depth-≥2 node with a `line` attribute shows "◉ View Source"
+in the radial menu. For GitHub repos this opens `github.com/blob/#L{line}` in
+a new tab. For local paths a brief toast shows `label at file:line`.
+
+---
+
 ## D3 Extensions
 
 The D3 renderer supports extensions for enhanced interactivity:
@@ -601,11 +684,16 @@ Fixing this properly requires implementing GL's "virtual layout" or "binding con
 | `codecarto/services/parsers/python_language_parser.py` | Python adapter |
 | `codecarto/services/parsers/c_language_parser.py` | C/H adapter |
 | `codecarto/services/graph_serializer.py` | NetworkX -> gJGF, depth-aware sizing |
-| `codecarto/models/custom_layouts/compound_layout.py` | 3-pass hierarchical layout (dirs→files→symbols) |
+| `codecarto/services/github_service.py` | GitHub API client + `resolve_github_token()` / `create_headers()` |
+| `codecarto/models/custom_layouts/compound_layout.py` | 4-pass hierarchical layout (dirs→files→symbols→sub-symbols, source-ordered) |
 | `codecarto/services/position_service.py` | Layout registry; registers compound_layout |
-| `web/src/features/graph/services/compound_layout.ts` | CompoundLayoutManager + GroupBounds; spatial bounding-circle computation |
-| `web/src/components/codecarto/control_panel/control_panel.ts` | 2-tab panel (Source / Graph) |
-| `web/src/state/actions.ts` | PlotActions: plotUnified, plotWholeRepo, plotCFile, plotCDirectory, … |
-| `web/src/features/graph/services/graph_renderer.ts` | D3 renderer + GraphNode type |
+| `web/src/features/graph/services/compound_layout.ts` | CompoundLayoutManager — bounding circles + `computeChildrenMap` (4-tier drag) |
+| `web/src/layout/panel_registry.ts` | Dock panel registration table (id/config/mount) — add new panels here |
+| `web/src/layout/layout_context.ts` | GL state hub — streaming, graphbase, GitHub auth status |
+| `web/src/layout/panels/graphbase_panel.ts` | Graph Library panel (Snapshots / Saved / History / Recent) |
+| `web/src/services/graphbase_service.ts` | `/db/*` client — bookmarks, snapshots, history |
+| `graphbase/__init__.py` | Submodule public surface — `from graphbase import graphdb, get_db` |
+| `graphbase/src/main.py` | MongoDB router (bookmarks / snapshots / history / graph CRUD) |
+| `web/src/features/graph/services/graph_renderer.ts` | D3 renderer + radial menu + onViewSource (github.com/blob/#L) |
 | `web/src/features/graph/services/renderers.ts` | Renderer registry |
 | `docs/llm/EXTENDING.md` | How to add renderers, language parsers, endpoints |

--- a/web/src/features/graph/services/streaming_renderer.ts
+++ b/web/src/features/graph/services/streaming_renderer.ts
@@ -320,6 +320,34 @@ export class StreamingGraphRenderer {
       textEl.attr('opacity', 1);
     }
 
+    // ── Source navigation ──────────────────────────────────────────────────
+    // Right-click or double-click on a symbol node → open github.com/blob
+    // view at the node's line number. Right-click calls preventDefault() so
+    // the browser's native context menu never appears; double-click is the
+    // modifier-key-free alternative.
+    const depth = (node.depth as number) ?? 0;
+    const line  = Number(node.line)  || 0;
+    const file  = (node.file as string) || '';
+
+    if (depth >= 2 && line > 0) {
+      group
+        .on('contextmenu', (event: MouseEvent) => {
+          event.preventDefault();
+          event.stopPropagation();
+          this._openSource(file, line, (node.label as string) || node.id, event.clientX, event.clientY);
+        })
+        .on('dblclick', (event: MouseEvent) => {
+          event.stopPropagation();
+          this._openSource(file, line, (node.label as string) || node.id, event.clientX, event.clientY);
+        });
+    } else if (depth < 2) {
+      // Dir/file nodes: right-click only prevents browser menu (no source to show)
+      group.on('contextmenu', (event: MouseEvent) => {
+        event.preventDefault();
+        event.stopPropagation();
+      });
+    }
+
     // Drag support (no simulation — positions are pre-computed)
     group.call(
       d3.drag<SVGGElement, unknown>()
@@ -447,6 +475,46 @@ export class StreamingGraphRenderer {
         .delay(300)
         .duration(500)
         .style('opacity', 1);
+    }
+  }
+
+  /**
+   * Open the source location for a symbol node.
+   * GitHub raw URLs are converted to github.com/blob/#L{line} in a new tab.
+   * Non-URL file paths show a small in-page toast at the click position.
+   */
+  private _openSource(file: string, line: number, label: string, cx: number, cy: number): void {
+    const rawMatch = file.match(
+      /^https:\/\/raw\.githubusercontent\.com\/([^/]+\/[^/]+)\/([^/]+)\/(.+)$/
+    );
+    if (rawMatch) {
+      window.open(
+        `https://github.com/${rawMatch[1]}/blob/${rawMatch[2]}/${rawMatch[3]}#L${line}`,
+        '_blank', 'noopener',
+      );
+    } else if (file.startsWith('http')) {
+      window.open(file, '_blank', 'noopener');
+    } else {
+      // Local file — show a compact floating badge near the cursor
+      const badge = document.createElement('div');
+      badge.style.cssText = [
+        'position:fixed',
+        `left:${cx + 8}px`,
+        `top:${cy - 28}px`,
+        'z-index:9999',
+        'background:#1a1a1a',
+        'border:1px solid #00ff4140',
+        'color:#00ff41',
+        'padding:4px 8px',
+        'font-size:11px',
+        'font-family:monospace',
+        'border-radius:4px',
+        'pointer-events:none',
+        'white-space:nowrap',
+      ].join(';');
+      badge.textContent = `${label}  ${file}:${line}`;
+      document.body.appendChild(badge);
+      setTimeout(() => badge.remove(), 3500);
     }
   }
 

--- a/web/src/layout/golden_layout_shell.ts
+++ b/web/src/layout/golden_layout_shell.ts
@@ -76,10 +76,11 @@ export const GoldenLayoutShell = (getCell: () => ICell): m.Component => {
       const theme = ctx.panelState.currentTheme;
       document.documentElement.setAttribute('data-theme', theme === 'terminal' ? '' : theme);
 
-      // Initialise languages, filesystem cache, and graphbase (non-blocking, each independent)
+      // Initialise languages, filesystem cache, graphbase and GitHub auth (all non-blocking)
       try { await ctx.actions.plot.initializeLanguages(); m.redraw(); } catch { /* non-fatal */ }
       await ctx.refreshCache();
-      ctx.refreshGraphbase(); // non-blocking probe — sets graphbaseAvailable flag
+      ctx.refreshGraphbase();        // probe graphbase — sets graphbaseAvailable
+      ctx.refreshGithubAuthStatus(); // probe GitHub auth — surfaces bad-token early
 
       HelpModal.maybeShowFirstTime();
     },
@@ -107,6 +108,21 @@ export const GoldenLayoutShell = (getCell: () => ICell): m.Component => {
             'Code Cartographer',
           ]),
           m('span.gl-app-header__spacer'),
+          // ── GitHub auth indicator ───────────────────────────────────────
+          ctx.githubAuthStatus
+            ? m('div.gl-app-header__gh-auth', {
+                title: ctx.githubAuthStatus.authenticated
+                  ? `GitHub: authenticated via ${ctx.githubAuthStatus.source}`
+                  : `GitHub: unauthenticated (60 req/h) — set CC_GITHUB_TOKEN or run 'gh auth login'`,
+                class: ctx.githubAuthStatus.authenticated
+                  ? 'gl-app-header__gh-auth--ok'
+                  : 'gl-app-header__gh-auth--warn',
+              }, [
+                m('span.gl-app-header__gh-dot'),
+                m('span.gl-app-header__gh-label',
+                  ctx.githubAuthStatus.authenticated ? 'GH' : 'GH?'),
+              ])
+            : null,
           ctx.hiddenDockPanels.length > 0
             ? m('div.gl-app-header__restore',
                 ctx.hiddenDockPanels.map((panelId) =>

--- a/web/src/layout/golden_layout_shell.ts
+++ b/web/src/layout/golden_layout_shell.ts
@@ -150,8 +150,12 @@ export const GoldenLayoutShell = (getCell: () => ICell): m.Component => {
             glInstance?.destroy();
             glInstance = null;
           },
-          // Right-click on the tab/dock area also opens the add-window menu.
+          // Ctrl+right-click on the dock area opens the add-window menu.
+          // Plain right-click is left to the graph renderer's own contextmenu
+          // handlers (which call preventDefault themselves for node targets) or
+          // falls through to the browser's native menu on empty chrome areas.
           oncontextmenu: (e: MouseEvent) => {
+            if (!e.ctrlKey) return;
             e.preventDefault();
             menuPos = { x: e.clientX, y: e.clientY };
             menuOpen = true;

--- a/web/src/layout/golden_layout_theme.css
+++ b/web/src/layout/golden_layout_theme.css
@@ -318,6 +318,26 @@
   border-color: var(--c-secondary, #00ff41);
 }
 
+/* GitHub auth indicator */
+.gl-app-header__gh-auth {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 0.7em;
+  letter-spacing: 0.5px;
+  cursor: default;
+  padding: 2px 6px;
+  border-radius: var(--border-radius, 4px);
+  border: 1px solid transparent;
+}
+.gl-app-header__gh-auth--ok  { color: var(--c-secondary, #00ff41); border-color: var(--c-secondary, #00ff4140); }
+.gl-app-header__gh-auth--warn { color: #f39c12; border-color: #f39c1240; }
+.gl-app-header__gh-dot {
+  width: 6px; height: 6px; border-radius: 50%;
+  background: currentColor;
+  flex-shrink: 0;
+}
+
 .gl-app-header__help-btn,
 .gl-app-header__add-btn {
   width: 24px;

--- a/web/src/layout/layout_context.ts
+++ b/web/src/layout/layout_context.ts
@@ -92,6 +92,9 @@ export class LayoutContext {
   /** Cached graph entries fetched from the backend cache endpoint. */
   public cachedGraphs: CachedEntry[] | null = null;
 
+  /** GitHub auth status from the backend's /auth/github endpoint. */
+  public githubAuthStatus: { source: string; authenticated: boolean; token_prefix?: string } | null = null;
+
   /** Graphbase availability, saved bookmarks, snapshots, and history. */
   public graphbaseAvailable = false;
   public graphbaseBookmarks: GraphbaseBookmark[] = [];
@@ -226,6 +229,17 @@ export class LayoutContext {
       this._cancelStream = null;
     }
     this.updatePanelState({ isLoading: false, statusMessage: 'Cancelled', progress: null });
+  }
+
+  /** Fetch and cache the GitHub auth status from the backend. */
+  public async refreshGithubAuthStatus(): Promise<void> {
+    try {
+      const r = await fetch(this.appState.api.authGithub);
+      if (r.ok) {
+        this.githubAuthStatus = await r.json();
+        m.redraw();
+      }
+    } catch { /* non-fatal */ }
   }
 
   /** Check graphbase availability and refresh the bookmark list. */

--- a/web/src/state/api_base.ts
+++ b/web/src/state/api_base.ts
@@ -33,4 +33,8 @@ export class API {
   get db(): string {
     return `${this._base}/db`;
   }
+
+  get authGithub(): string {
+    return `${this._base}/auth/github`;
+  }
 }


### PR DESCRIPTION
Closes #73 (supersedes the stacked version — rebased cleanly onto main after #74 merged).

## Changes

### GitHub token resolution (`github_service.py`)
`create_headers()` read `GITHUB_TOKEN` first. Since `gh` CLI also reads `GITHUB_TOKEN` first, a stale env var shadowed the valid keyring credential at every level. New `resolve_github_token()` resolution order:
1. `CC_GITHUB_TOKEN` env var — project-specific, won't conflict with system `GITHUB_TOKEN`
2. **`gh auth token --hostname github.com`** with `GITHUB_TOKEN`/`GH_TOKEN` stripped from subprocess env → keyring is consulted, not the bad env var
3. `GITHUB_TOKEN` / `GH_TOKEN` env var — legacy / Docker Compose
4. Docker secret
5. Unauthenticated (logs warning)

Token resolved once at startup (cached). `repo_router.py` direct env-var read replaced with `get_github_token()`. `GET /auth/github` exposes the source for diagnostics. Frontend header shows green/amber GH indicator.

Also fixes `graphbase/__init__.py` (already in #74 squash — carried forward).

### View Source on streaming renderer (`streaming_renderer.ts`)
The radial menu "View Source" only existed in `graph_renderer.ts` (static/replay path). The streaming renderer — used for all normal SSE repo plots — had no contextmenu handler at all, so right-click fell straight through to the browser's native menu.

Fixes: depth≥2 nodes with a `line` attribute now get both a `contextmenu` handler (preventDefault + `_openSource`) and a `dblclick` handler so View Source is reachable via either right-click or double-click. `_openSource()` converts `raw.githubusercontent.com` URLs to `github.com/blob/#L{line}` in a new tab; local paths show a floating badge near the cursor.

`golden_layout_shell.ts`: add-window menu changed from plain right-click to **Ctrl+right-click** so it doesn't conflict with graph canvas event handling.

### Docs
`api.md`: `/auth/github` and all `/db/*` endpoints documented. `ARCHITECTURE.md`: GitHub token resolution, Graphbase store, code-map layout sections.

## Test plan
- [ ] Restart server → log shows `INFO GitHub auth: gh CLI keyring (token: gho_…)` and `INFO Graphbase router mounted at /db`
- [ ] `GET /auth/github` → `{"source":"gh CLI keyring","authenticated":true,...}`
- [ ] Header shows green GH dot
- [ ] Right-click on a function node → navigates to GitHub blob at correct line (no browser native menu)
- [ ] Double-click on a function node → same navigation
- [ ] Ctrl+right-click on dock area → opens "+" add-window menu

🤖 Generated with [Claude Code](https://claude.ai/claude-code)